### PR TITLE
feat: Add admin DNS record management API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+- v0.22.0:
+  - NOTE: Admin API is disabled by default. Set an admin token in `[api.admin]` section to enable it.
+  - New
+    - Admin API for managing DNS records (CRUD operations)
+    - Bearer token authentication for admin endpoints
+    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
+    - Comprehensive DNS record validation (type, value, TTL)
+  - Changed
+    - DNS server now serves both challenge records and managed records from database
+    - FQDN normalization on ingress for consistency
+    - Added database index for efficient record lookups
 - v0.21.6:
   - Changed
     - Update base image to golang:1.26-alpine3.23
@@ -48,6 +59,76 @@
 - v0.18.1:
   - Changed
     - Dependencies update
+- v0.22.0:
+  - NOTE: Admin API is disabled by default. Set an admin token in `[api.admin]` section to enable it.
+  - New
+    - Admin API for managing DNS records (CRUD operations)
+    - Bearer token authentication for admin endpoints
+    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
+    - Comprehensive DNS record validation (type, value, TTL)
+  - Changed
+    - DNS server now serves both challenge records and managed records from database
+    - FQDN normalization on ingress for consistency
+    - Added database index for efficient record lookups
+- v0.21.6:
+  - Changed
+    - Update base image to golang:1.26-alpine3.23
+    - Dependencies update
+- v0.21.5:
+  - Changed
+    - Remove asciicast link from README
+    - Dependencies update
+- v0.21.4:
+  - Changed
+    - Add token to checkout step in workflow
+    - Fix tag command in monthly patch release workflow
+    - Refactor Git configuration and tag creation step
+    - Dependencies update
+- v0.21.3:
+  - Changed
+    - Update the Go version and add GH action for the automatic release handling
+    - Dependencies update
+- v0.21.2:
+  - Changed
+    - Dependencies update
+- v0.21.1:
+  - Changed
+    - Dependencies update
+- v0.21.0:
+  - Changed
+    - Update the Lego version
+    - Dependencies update
+- v0.20.0:
+  - New
+    - Add the Codeowners file
+  - Changed
+    - Update the Go version
+    - Dependencies update
+- v0.19.1:
+  - Changed
+    - Update the Alpine version
+    - Dependencies update
+- v0.19.0:
+  - Changed
+    - Update the Alpine version
+    - Dependencies update
+- v0.18.2:
+  - Changed
+    - Bump the used version
+    - Dependencies update
+- v0.18.1:
+  - Changed
+    - Dependencies update
+- v0.22.0:
+  - New
+    - Admin API for managing DNS records (CRUD operations)
+    - Bearer token authentication for admin endpoints
+    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
+    - Comprehensive DNS record validation (type, value, TTL)
+  - Changed
+    - DNS server now serves both challenge records and managed records from database
+    - FQDN normalization on ingress for consistency
+    - Added database index for efficient record lookups
 - v0.18.0:
   - Switched to go 1.24
 - v0.17.1:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For longer explanation of the underlying issue and other proposed solutions, see
 
 - Simplified DNS server, serving your ACME DNS challenges (TXT)
 - Custom records (have your required A, AAAA, NS, etc. records served)
+- Admin API for managing DNS records with Bearer token authentication
 - HTTP API automatically acquires and uses Let's Encrypt TLS certificate
 - Limit /update API endpoint access to specific CIDR mask(s), defined in the /register request
 - Supports SQLite & PostgreSQL as DB backends
@@ -37,6 +38,139 @@ Using acme-dns is a three-step process (provided you already have the self-hoste
 - Crontab and forget.
 
 ## API
+
+### Admin API
+
+The Admin API allows authenticated administrators to manage DNS records stored in the database. All endpoints require Bearer token authentication and are disabled by default.
+
+**Enabling the Admin API**
+
+To enable the Admin API, set an admin token in your configuration:
+
+```toml
+[api.admin]
+token = "your-secret-admin-token-here"
+```
+
+**Authentication**
+
+All Admin API requests require the `Authorization` header with a Bearer token:
+
+```
+Authorization: Bearer your-secret-admin-token-here
+```
+
+#### List records
+
+Retrieve all DNS records, optionally filtered by record type or name.
+
+`GET /admin/records?type=TYPE&name=NAME`
+
+**Query Parameters:**
+- `type` (optional): Filter by DNS record type (A, AAAA, NS, TXT, CNAME, MX, etc.)
+- `name` (optional): Filter by record name (domain name)
+
+**Response**
+
+`Status: 200 OK`
+
+```json
+[
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "example.org.",
+    "type": "A",
+    "value": "192.0.2.1",
+    "ttl": 3600,
+    "created": 1719259200
+  }
+]
+```
+
+#### Create record
+
+Create a new DNS record.
+
+`POST /admin/records`
+
+**Request body:**
+
+```json
+{
+  "name": "example.org",
+  "type": "A",
+  "value": "192.0.2.1",
+  "ttl": 3600
+}
+```
+
+**Fields:**
+- `name`: Domain name for the record (required)
+- `type`: DNS record type: A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR (required)
+- `value`: Record value (required)
+  - A: IPv4 address
+  - AAAA: IPv6 address
+  - NS, CNAME, PTR, MX: Hostname
+  - TXT: Text string (automatically quoted if not already)
+  - SRV: Service record format
+- `ttl`: Time-to-live in seconds (optional, defaults to 300)
+
+**Response**
+
+`Status: 201 Created`
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "example.org.",
+  "type": "A",
+  "value": "192.0.2.1",
+  "ttl": 3600,
+  "created": 1719259200
+}
+```
+
+#### Update record
+
+Update an existing DNS record by ID.
+
+`PUT /admin/records/:id`
+
+**Request body:**
+
+```json
+{
+  "name": "example.org",
+  "type": "A",
+  "value": "192.0.2.2",
+  "ttl": 3600
+}
+```
+
+**Response**
+
+`Status: 200 OK`
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "example.org.",
+  "type": "A",
+  "value": "192.0.2.2",
+  "ttl": 3600,
+  "created": 1719259200
+}
+```
+
+#### Delete record
+
+Delete a DNS record by ID.
+
+`DELETE /admin/records/:id`
+
+**Response**
+
+`Status: 204 No Content`
 
 ### Register endpoint
 
@@ -267,6 +401,9 @@ corsorigins = [
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+# Admin API — leave token empty to disable admin endpoints
+# token = "your-secret-admin-token-here"
+token = ""
 
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"

--- a/api.go
+++ b/api.go
@@ -1,14 +1,47 @@
 package main
 
 import (
+	"crypto/subtle"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
+	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
+	"strings"
+	"time"
 )
 
+// toFQDN ensures a DNS name ends with a trailing dot for consistent storage and lookup.
+func toFQDN(name string) string {
+	name = strings.ToLower(name)
+	if !strings.HasSuffix(name, ".") {
+		name += "."
+	}
+	return name
+}
+
+// stripOuterQuotes removes a single layer of surrounding double-quotes from TXT values
+// so the DB always stores the raw string content regardless of how the caller supplied it.
+func stripOuterQuotes(value string) string {
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+// probeRR validates that rtype+value form a parseable DNS RR using a placeholder name and TTL.
+func probeRR(rtype, value string) bool {
+	if rtype == "TXT" {
+		value = `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+	}
+	_, err := dns.NewRR(fmt.Sprintf("probe.invalid. 300 IN %s %s", rtype, value))
+	return err == nil
+}
 // RegResponse is a struct for registration response JSON
 type RegResponse struct {
 	Username   string   `json:"username"`
@@ -109,4 +142,200 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusOK)
+}
+
+// adminRecordRequest is the request body for creating/updating a DNS record
+type adminRecordRequest struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	TTL   int    `json:"ttl"`
+}
+
+func adminBearerMiddleware(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		token := Config.API.Admin.Token
+		auth := r.Header.Get("Authorization")
+		provided := strings.TrimPrefix(auth, "Bearer ")
+		if subtle.ConstantTimeCompare([]byte(token), []byte(provided)) != 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write(jsonError("unauthorized"))
+			return
+		}
+		next(w, r, ps)
+	}
+}
+
+func adminListRecords(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	filterType := strings.ToUpper(r.URL.Query().Get("type"))
+	filterName := r.URL.Query().Get("name")
+	if filterName != "" {
+		filterName = toFQDN(filterName)
+	}
+	records, err := DB.ListRecords(filterType, filterName)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in admin handler")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(jsonError("db_error"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(records)
+}
+
+func adminCreateRecord(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var req adminRecordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("malformed_json_payload"))
+		return
+	}
+	if req.Name == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_name"))
+		return
+	}
+	if !validRecordType(req.Type) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_type"))
+		return
+	}
+	if !validRecordValue(req.Type, req.Value) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_value"))
+		return
+	}
+	if !probeRR(req.Type, req.Value) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_value"))
+		return
+	}
+	ttl := req.TTL
+	if ttl == 0 {
+		ttl = 300
+	}
+	if !validTTL(ttl) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_ttl"))
+		return
+	}
+	rec := DNSRecord{
+		ID:      uuid.New().String(),
+		Name:    toFQDN(req.Name),
+		Type:    req.Type,
+		Value:   stripOuterQuotes(req.Value),
+		TTL:     ttl,
+		Created: time.Now().Unix(),
+	}
+	if err := DB.CreateRecord(rec); err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in admin handler")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(jsonError("db_error"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(rec)
+}
+
+func adminUpdateRecord(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	id := ps.ByName("id")
+	var req adminRecordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("malformed_json_payload"))
+		return
+	}
+	if req.Name == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_name"))
+		return
+	}
+	if !validRecordType(req.Type) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_type"))
+		return
+	}
+	if !validRecordValue(req.Type, req.Value) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_value"))
+		return
+	}
+	if !probeRR(req.Type, req.Value) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_record_value"))
+		return
+	}
+	if req.TTL != 0 && !validTTL(req.TTL) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(jsonError("invalid_ttl"))
+		return
+	}
+	ttl := req.TTL
+	if ttl == 0 {
+		ttl = 300
+	}
+	rec := DNSRecord{ID: id, Name: toFQDN(req.Name), Type: req.Type, Value: stripOuterQuotes(req.Value), TTL: ttl}
+	if err := DB.UpdateRecord(rec); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write(jsonError("record_not_found"))
+		} else {
+			log.WithFields(log.Fields{"error": err.Error()}).Error("Error in admin handler")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(jsonError("db_error"))
+		}
+		return
+	}
+	// Fetch the full updated record to include the original Created timestamp
+	updated, err := DB.GetRecord(id)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in admin handler")
+		w.Header().Set("Content-Type", "application/json")
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write(jsonError("record_not_found"))
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(jsonError("db_error"))
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(updated)
+}
+
+func adminDeleteRecord(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	id := ps.ByName("id")
+	if err := DB.DeleteRecord(id); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write(jsonError("record_not_found"))
+		} else {
+			log.WithFields(log.Fields{"error": err.Error()}).Error("Error in admin handler")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(jsonError("db_error"))
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -442,3 +442,302 @@ func TestApiHealthCheck(t *testing.T) {
 	e := getExpect(t, server)
 	e.GET("/health").Expect().Status(http.StatusOK)
 }
+
+func setupAdminRouter(t *testing.T, token string) (*httptest.Server, *httpexpect.Expect) {
+	t.Helper()
+	api := httprouter.New()
+	var dbcfg = dbsettings{Engine: "sqlite3", Connection: ":memory:"}
+	var httpapicfg = httpapi{
+		Port:        "8080",
+		TLS:         "none",
+		CorsOrigins: []string{"*"},
+		UseHeader:   false,
+		HeaderName:  "X-Forwarded-For",
+		Admin:       adminconfig{Token: token},
+	}
+	Config = DNSConfig{API: httpapicfg, Database: dbcfg}
+	newDB := new(acmedb)
+	_ = newDB.Init(Config.Database.Engine, Config.Database.Connection)
+	oldDB := DB
+	DB = newDB
+	t.Cleanup(func() { DB = oldDB })
+
+	api.POST("/register", webRegisterPost)
+	api.GET("/health", healthCheck)
+	api.POST("/update", Auth(webUpdatePost))
+	api.GET("/admin/records", adminBearerMiddleware(adminListRecords))
+	api.POST("/admin/records", adminBearerMiddleware(adminCreateRecord))
+	api.PUT("/admin/records/:id", adminBearerMiddleware(adminUpdateRecord))
+	api.DELETE("/admin/records/:id", adminBearerMiddleware(adminDeleteRecord))
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE"},
+	})
+	server := httptest.NewServer(c.Handler(api))
+	t.Cleanup(func() { server.Close() })
+	e := getExpect(t, server)
+	return server, e
+}
+
+func TestAdminListRecordsUnauthorized(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	e.GET("/admin/records").Expect().Status(http.StatusUnauthorized)
+}
+
+func TestAdminCreateRecord(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "test.example.com", "type": "A", "value": "1.2.3.4", "ttl": 300}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().
+		Status(http.StatusCreated).
+		JSON().Object().ContainsKey("id")
+}
+
+func TestAdminCreateRecordInvalidType(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "test.example.com", "type": "INVALID", "value": "1.2.3.4", "ttl": 300}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().
+		Status(http.StatusBadRequest)
+}
+
+func TestAdminListRecords(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "test.example.com", "type": "A", "value": "1.2.3.4", "ttl": 60}
+	created := e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().
+		Status(http.StatusCreated).
+		JSON().Object()
+	createdID := created.Value("id").String().Raw()
+
+	arr := e.GET("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Array()
+
+	arr.Length().Equal(1)
+
+	// Verify the created record appears in the list
+	found := false
+	for _, item := range arr.Iter() {
+		if item.Object().Value("id").String().Raw() == createdID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("created record id %s not found in list", createdID)
+	}
+}
+
+func TestAdminDeleteRecord(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "del.example.com", "type": "A", "value": "1.2.3.4", "ttl": 60}
+	id := e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().Status(http.StatusCreated).
+		JSON().Object().Value("id").String().Raw()
+
+	e.DELETE("/admin/records/"+id).
+		WithHeader("Authorization", "Bearer test-token").
+		Expect().Status(http.StatusNoContent)
+
+	e.GET("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		Expect().
+		Status(http.StatusOK).
+		JSON().Array().Length().Equal(0)
+}
+
+func TestAdminUpdateRecord(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	// Create a record
+	body := map[string]interface{}{"name": "upd.example.com", "type": "A", "value": "1.2.3.4", "ttl": 60}
+	id := e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().Status(http.StatusCreated).
+		JSON().Object().Value("id").String().Raw()
+
+	// Update it with a new value and TTL
+	updBody := map[string]interface{}{"name": "upd.example.com", "type": "A", "value": "5.6.7.8", "ttl": 120}
+	obj := e.PUT("/admin/records/"+id).
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(updBody).
+		Expect().Status(http.StatusOK).
+		JSON().Object()
+	obj.Value("value").String().Equal("5.6.7.8")
+	obj.Value("ttl").Number().Equal(120)
+
+	// Not-found case: PUT to a non-existent UUID
+	nonExistent := "00000000-0000-0000-0000-000000000000"
+	e.PUT("/admin/records/"+nonExistent).
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(updBody).
+		Expect().Status(http.StatusNotFound)
+
+	// Invalid-type case: should return 400
+	invalidTypeBody := map[string]interface{}{"name": "upd.example.com", "type": "INVALID", "value": "5.6.7.8", "ttl": 60}
+	e.PUT("/admin/records/"+id).
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(invalidTypeBody).
+		Expect().Status(http.StatusBadRequest)
+}
+
+func TestAdminWrongToken(t *testing.T) {
+	_, e := setupAdminRouter(t, "correct-token")
+	e.GET("/admin/records").WithHeader("Authorization", "Bearer wrong-token").Expect().Status(http.StatusUnauthorized)
+}
+
+func TestAdminCreateRecordInvalidValue(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	payload := map[string]interface{}{
+		"name":  "test.example.com",
+		"type":  "A",
+		"value": "not-an-ip",
+		"ttl":   60,
+	}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(payload).
+		Expect().Status(http.StatusBadRequest)
+}
+
+func TestAdminCreateRecordInvalidMXValue(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	payload := map[string]interface{}{
+		"name":  "test.example.com",
+		"type":  "MX",
+		"value": "not-a-valid-mx",
+		"ttl":   60,
+	}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(payload).
+		Expect().Status(http.StatusBadRequest)
+}
+
+func TestAdminCreateCAARecord(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	payload := map[string]interface{}{
+		"name":  "caa.example.com",
+		"type":  "CAA",
+		"value": `0 issue "letsencrypt.org"`,
+		"ttl":   300,
+	}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(payload).
+		Expect().Status(http.StatusCreated).JSON().Object().ContainsKey("id")
+}
+
+func TestAdminTXTValueQuoteStripping(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	// Value submitted with surrounding quotes should be stored and returned without them.
+	payload := map[string]interface{}{
+		"name":  "txt.example.com",
+		"type":  "TXT",
+		"value": `"some token"`,
+		"ttl":   60,
+	}
+	obj := e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(payload).
+		Expect().Status(http.StatusCreated).JSON().Object()
+	obj.Value("value").String().Equal("some token")
+}
+
+func TestAdminListRecordsFilter(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+	// Create an A record and a CNAME record
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(map[string]interface{}{"name": "a.example.com", "type": "A", "value": "1.2.3.4", "ttl": 60}).
+		Expect().Status(http.StatusCreated)
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(map[string]interface{}{"name": "b.example.com", "type": "CNAME", "value": "a.example.com", "ttl": 60}).
+		Expect().Status(http.StatusCreated)
+	// Filter by type=A — should only return 1 record
+	e.GET("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithQuery("type", "A").
+		Expect().Status(http.StatusOK).JSON().Array().Length().Equal(1)
+	// Filter by name=b.example.com — should only return 1 record
+	e.GET("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithQuery("name", "b.example.com").
+		Expect().Status(http.StatusOK).JSON().Array().Length().Equal(1)
+}
+
+func setupRouterWithToken(t *testing.T, token string) (*httptest.Server, *httpexpect.Expect) {
+	t.Helper()
+	api := httprouter.New()
+	var dbcfg = dbsettings{Engine: "sqlite3", Connection: ":memory:"}
+	var httpapicfg = httpapi{
+		Port:        "8080",
+		TLS:         "none",
+		CorsOrigins: []string{"*"},
+		UseHeader:   false,
+		HeaderName:  "X-Forwarded-For",
+		Admin:       adminconfig{Token: token},
+	}
+	Config = DNSConfig{API: httpapicfg, Database: dbcfg}
+	newDB := new(acmedb)
+	_ = newDB.Init(Config.Database.Engine, Config.Database.Connection)
+	oldDB := DB
+	DB = newDB
+	t.Cleanup(func() { DB = oldDB })
+
+	api.GET("/health", healthCheck)
+	if token != "" {
+		api.GET("/admin/records", adminBearerMiddleware(adminListRecords))
+		api.POST("/admin/records", adminBearerMiddleware(adminCreateRecord))
+		api.PUT("/admin/records/:id", adminBearerMiddleware(adminUpdateRecord))
+		api.DELETE("/admin/records/:id", adminBearerMiddleware(adminDeleteRecord))
+	}
+	server := httptest.NewServer(api)
+	t.Cleanup(func() { server.Close() })
+	return server, getExpect(t, server)
+}
+
+func TestAdminRoutesAbsentWithNoToken(t *testing.T) {
+	_, e := setupRouterWithToken(t, "")
+	e.GET("/admin/records").Expect().Status(http.StatusNotFound)
+	e.POST("/admin/records").Expect().Status(http.StatusNotFound)
+}
+
+func TestAdminUpdatePreservesCreated(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "ts.example.com", "type": "A", "value": "1.1.1.1", "ttl": 60}
+	created := e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().Status(http.StatusCreated).
+		JSON().Object()
+	id := created.Value("id").String().Raw()
+	originalCreated := created.Value("created").Number().Raw()
+
+	updBody := map[string]interface{}{"name": "ts.example.com", "type": "A", "value": "2.2.2.2", "ttl": 120}
+	updated := e.PUT("/admin/records/"+id).
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(updBody).
+		Expect().Status(http.StatusOK).
+		JSON().Object()
+	updated.Value("created").Number().Equal(originalCreated)
+	updated.Value("value").String().Equal("2.2.2.2")
+}

--- a/config.cfg
+++ b/config.cfg
@@ -54,6 +54,10 @@ use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
 
+# To enable the admin API, add an [api.admin] section with a secret token:
+# [api.admin]
+# token = "your-secret-admin-token-here"
+
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"
 loglevel = "debug"

--- a/db.go
+++ b/db.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DBVersion shows the database version this code uses. This is used for update checks.
-var DBVersion = 1
+var DBVersion = 2
 
 var acmeTable = `
 	CREATE TABLE IF NOT EXISTS acmedns(
@@ -47,6 +47,19 @@ var txtTablePG = `
 		Value   TEXT NOT NULL DEFAULT '',
 		LastUpdate INT
 	);`
+
+var dnsRecordsTable = `
+	CREATE TABLE IF NOT EXISTS dns_records (
+		id      TEXT PRIMARY KEY,
+		name    TEXT NOT NULL,
+		type    TEXT NOT NULL,
+		value   TEXT NOT NULL,
+		ttl     INTEGER NOT NULL DEFAULT 300,
+		created INTEGER NOT NULL
+	);`
+
+var dnsRecordsIndex = `
+	CREATE INDEX IF NOT EXISTS idx_dns_records_name_type ON dns_records (name, type);`
 
 // getSQLiteStmt replaces all PostgreSQL prepared statement placeholders (eg. $1, $2) with SQLite variant "?"
 func getSQLiteStmt(s string) string {
@@ -80,13 +93,15 @@ func (d *acmedb) Init(engine string, connection string) error {
 	} else {
 		_, _ = d.DB.Exec(txtTablePG)
 	}
+	_, _ = d.DB.Exec(dnsRecordsTable)
+	_, _ = d.DB.Exec(dnsRecordsIndex)
 	// If everything is fine, handle db upgrade tasks
 	if err == nil {
 		err = d.checkDBUpgrades(versionString)
 	}
 	if err == nil {
 		if versionString == "0" {
-			// No errors so we should now be in version 1
+		// No errors so we should now be in the current version
 			insversion := fmt.Sprintf("INSERT INTO acmedns (Name, Value) values('db_version', '%d')", DBVersion)
 			_, err = db.Exec(insversion)
 		}
@@ -108,8 +123,20 @@ func (d *acmedb) checkDBUpgrades(versionString string) error {
 }
 
 func (d *acmedb) handleDBUpgrades(version int) error {
-	if version == 0 {
-		return d.handleDBUpgradeTo1()
+	for version < DBVersion {
+		var err error
+		switch version {
+		case 0:
+			err = d.handleDBUpgradeTo1()
+		case 1:
+			err = d.handleDBUpgradeTo2()
+		default:
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		version++
 	}
 	return nil
 }
@@ -163,6 +190,11 @@ func (d *acmedb) handleDBUpgradeTo1() error {
 		_, _ = tx.Exec("ALTER TABLE records DROP COLUMN IF EXISTS LastActive")
 	}
 	_, err = tx.Exec("UPDATE acmedns SET Value='1' WHERE Name='db_version'")
+	return err
+}
+
+func (d *acmedb) handleDBUpgradeTo2() error {
+	_, err := d.DB.Exec("UPDATE acmedns SET Value='2' WHERE Name='db_version'")
 	return err
 }
 
@@ -309,6 +341,95 @@ func (d *acmedb) Update(a ACMETxtPost) error {
 	_, err = sm.Exec(a.Value, timenow, a.Subdomain)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (d *acmedb) CreateRecord(rec DNSRecord) error {
+	d.Lock()
+	defer d.Unlock()
+	stmt := `INSERT INTO dns_records (id, name, type, value, ttl, created) VALUES ($1, $2, $3, $4, $5, $6)`
+	if Config.Database.Engine == "sqlite3" {
+		stmt = getSQLiteStmt(stmt)
+	}
+	_, err := d.DB.Exec(stmt, rec.ID, rec.Name, rec.Type, rec.Value, rec.TTL, rec.Created)
+	return err
+}
+
+func (d *acmedb) GetRecord(id string) (DNSRecord, error) {
+	d.Lock()
+	defer d.Unlock()
+	q := `SELECT id, name, type, value, ttl, created FROM dns_records WHERE id = $1`
+	if Config.Database.Engine == "sqlite3" {
+		q = getSQLiteStmt(q)
+	}
+	var r DNSRecord
+	err := d.DB.QueryRow(q, id).Scan(&r.ID, &r.Name, &r.Type, &r.Value, &r.TTL, &r.Created)
+	if err == sql.ErrNoRows {
+		return DNSRecord{}, sql.ErrNoRows
+	}
+	return r, err
+}
+
+func (d *acmedb) ListRecords(filterType, filterName string) ([]DNSRecord, error) {
+	d.Lock()
+	defer d.Unlock()
+	q := `SELECT id, name, type, value, ttl, created FROM dns_records WHERE ($1 = '' OR type = $2) AND ($3 = '' OR name = $4)`
+	if Config.Database.Engine == "sqlite3" {
+		q = getSQLiteStmt(q)
+	}
+	rows, err := d.DB.Query(q, filterType, filterType, filterName, filterName)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+	var records []DNSRecord
+	for rows.Next() {
+		var r DNSRecord
+		if err := rows.Scan(&r.ID, &r.Name, &r.Type, &r.Value, &r.TTL, &r.Created); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if records == nil {
+		records = []DNSRecord{}
+	}
+	return records, nil
+}
+
+func (d *acmedb) UpdateRecord(rec DNSRecord) error {
+	d.Lock()
+	defer d.Unlock()
+	stmt := `UPDATE dns_records SET name=$1, type=$2, value=$3, ttl=$4 WHERE id=$5`
+	if Config.Database.Engine == "sqlite3" {
+		stmt = getSQLiteStmt(stmt)
+	}
+	result, err := d.DB.Exec(stmt, rec.Name, rec.Type, rec.Value, rec.TTL, rec.ID)
+	if err != nil {
+		return err
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (d *acmedb) DeleteRecord(id string) error {
+	d.Lock()
+	defer d.Unlock()
+	stmt := `DELETE FROM dns_records WHERE id=$1`
+	if Config.Database.Engine == "sqlite3" {
+		stmt = getSQLiteStmt(stmt)
+	}
+	result, err := d.DB.Exec(stmt, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		return sql.ErrNoRows
 	}
 	return nil
 }

--- a/db_test.go
+++ b/db_test.go
@@ -275,6 +275,74 @@ func TestGetTXTForDomain(t *testing.T) {
 	}
 }
 
+func TestCreateAndListRecord(t *testing.T) {
+	rec := DNSRecord{
+		ID:      "test-uuid-1",
+		Name:    "sub.example.com.",
+		Type:    "A",
+		Value:   "1.2.3.4",
+		TTL:     300,
+		Created: 0,
+	}
+	err := DB.CreateRecord(rec)
+	if err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.DeleteRecord("test-uuid-1") })
+
+	records, err := DB.ListRecords("", "")
+	if err != nil {
+		t.Fatalf("ListRecords: %v", err)
+	}
+	found := false
+	for _, r := range records {
+		if r.ID == "test-uuid-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected record test-uuid-1 in list, got %v", records)
+	}
+}
+
+func TestUpdateRecord(t *testing.T) {
+	rec := DNSRecord{ID: "upd-1", Name: "a.example.com.", Type: "A", Value: "1.1.1.1", TTL: 60, Created: 0}
+	_ = DB.CreateRecord(rec)
+	t.Cleanup(func() { _ = DB.DeleteRecord("upd-1") })
+
+	rec.Value = "2.2.2.2"
+	err := DB.UpdateRecord(rec)
+	if err != nil {
+		t.Fatalf("UpdateRecord: %v", err)
+	}
+	records, _ := DB.ListRecords("A", "a.example.com.")
+	if len(records) == 0 || records[0].Value != "2.2.2.2" {
+		t.Fatalf("expected updated value 2.2.2.2, got %v", records)
+	}
+}
+
+func TestUpdateRecordNotFound(t *testing.T) {
+	err := DB.UpdateRecord(DNSRecord{ID: "nonexistent", Name: "x.example.com.", Type: "A", Value: "1.1.1.1", TTL: 60})
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows for missing ID, got %v", err)
+	}
+}
+
+func TestDeleteRecord(t *testing.T) {
+	rec := DNSRecord{ID: "del-1", Name: "b.example.com.", Type: "A", Value: "3.3.3.3", TTL: 60, Created: 0}
+	_ = DB.CreateRecord(rec)
+	t.Cleanup(func() { _ = DB.DeleteRecord("del-1") })
+
+	err := DB.DeleteRecord("del-1")
+	if err != nil {
+		t.Fatalf("DeleteRecord: %v", err)
+	}
+	records, _ := DB.ListRecords("A", "b.example.com.")
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records after delete, got %d", len(records))
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	// Create  reg to refer to
 	reg, err := DB.Register(cidrslice{})

--- a/dns.go
+++ b/dns.go
@@ -209,6 +209,18 @@ func (d *DNSServer) answer(q dns.Question) ([]dns.RR, int, bool, error) {
 			r = append(r, txtRRs...)
 		}
 	}
+	// Fall through to managed dns_records if no static or ACME records matched
+	if len(r) == 0 {
+		managed, nameExists := d.answerManaged(q)
+		if len(managed) > 0 {
+			r = managed
+			authoritative = true
+		} else if nameExists {
+			// Name exists in dns_records but not for this type: NODATA (NOERROR, empty answer)
+			rcode = dns.RcodeSuccess
+			authoritative = true
+		}
+	}
 	if len(r) > 0 {
 		// Make sure that we return NOERROR if there were dynamic records for the domain
 		rcode = dns.RcodeSuccess
@@ -242,4 +254,39 @@ func (d *DNSServer) answerOwnChallenge(q dns.Question) ([]dns.RR, error) {
 	r.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 1}
 	r.Txt = append(r.Txt, d.PersonalKeyAuth)
 	return []dns.RR{r}, nil
+}
+
+func (d *DNSServer) answerManaged(q dns.Question) ([]dns.RR, bool) {
+	qtype := dns.TypeToString[q.Qtype]
+	if qtype == "" {
+		return nil, false
+	}
+	name := strings.ToLower(q.Name)
+	// Check if the name exists at all (any type) to distinguish NXDOMAIN from NODATA.
+	allRecords, err := d.DB.ListRecords("", name)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Debug("Error querying managed records")
+		return nil, false
+	}
+	if len(allRecords) == 0 {
+		return nil, false
+	}
+	var rrs []dns.RR
+	for _, rec := range allRecords {
+		if rec.Type != qtype {
+			continue
+		}
+		value := rec.Value
+		if rec.Type == "TXT" {
+			value = `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+		}
+		rrStr := fmt.Sprintf("%s %d IN %s %s", rec.Name, rec.TTL, rec.Type, value)
+		rr, err := dns.NewRR(rrStr)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err.Error(), "record": rrStr}).Warning("Could not parse managed RR")
+			continue
+		}
+		rrs = append(rrs, rr)
+	}
+	return rrs, true
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -279,3 +279,72 @@ func TestCaseInsensitiveResolveSOA(t *testing.T) {
 		t.Error("No SOA answer for DNS query")
 	}
 }
+
+func TestAnswerManagedARecord(t *testing.T) {
+	rec := DNSRecord{
+		ID: "managed-test-1", Name: "managed.auth.example.org.", Type: "A", Value: "5.6.7.8", TTL: 300, Created: 0,
+	}
+	err := DB.CreateRecord(rec)
+	if err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.DeleteRecord("managed-test-1") })
+
+	q := dns.Question{Name: "managed.auth.example.org.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	rrs, rcode, _, err := dnsserver.answer(q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Fatalf("expected NOERROR, got %s", dns.RcodeToString[rcode])
+	}
+	if len(rrs) == 0 {
+		t.Fatal("expected at least one RR in answer")
+	}
+}
+
+func TestAnswerManagedNODATA(t *testing.T) {
+	// Name exists in dns_records as A, query for AAAA — must be NODATA (NOERROR, empty answer).
+	rec := DNSRecord{
+		ID: "nodata-test-1", Name: "nodata.auth.example.org.", Type: "A", Value: "1.2.3.4", TTL: 300, Created: 0,
+	}
+	if err := DB.CreateRecord(rec); err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.DeleteRecord("nodata-test-1") })
+
+	q := dns.Question{Name: "nodata.auth.example.org.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	rrs, rcode, _, err := dnsserver.answer(q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Fatalf("expected NOERROR (NODATA) for existing name with wrong type, got %s", dns.RcodeToString[rcode])
+	}
+	if len(rrs) != 0 {
+		t.Fatalf("expected empty answer section for NODATA, got %d records", len(rrs))
+	}
+}
+
+func TestAnswerManagedCAARecord(t *testing.T) {
+	// CAA value must not be quote-wrapped — it has its own tag-value structure.
+	rec := DNSRecord{
+		ID: "caa-test-1", Name: "caa.auth.example.org.", Type: "CAA", Value: `0 issue "letsencrypt.org"`, TTL: 300, Created: 0,
+	}
+	if err := DB.CreateRecord(rec); err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.DeleteRecord("caa-test-1") })
+
+	q := dns.Question{Name: "caa.auth.example.org.", Qtype: dns.TypeCAA, Qclass: dns.ClassINET}
+	rrs, rcode, _, err := dnsserver.answer(q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Fatalf("expected NOERROR for CAA query, got %s", dns.RcodeToString[rcode])
+	}
+	if len(rrs) == 0 {
+		t.Fatal("expected CAA record in answer, got none")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,8 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsServers []*DNSServer)
 	api := httprouter.New()
 	c := cors.New(cors.Options{
 		AllowedOrigins:     config.API.CorsOrigins,
-		AllowedMethods:     []string{"GET", "POST"},
+		AllowedMethods:     []string{"GET", "POST", "PUT", "DELETE"},
+		AllowedHeaders:     []string{"Authorization", "Content-Type", "X-Api-User", "X-Api-Key"},
 		OptionsPassthrough: false,
 		Debug:              config.General.Debug,
 	})
@@ -130,6 +131,12 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsServers []*DNSServer)
 	}
 	api.POST("/update", Auth(webUpdatePost))
 	api.GET("/health", healthCheck)
+	if config.API.Admin.Token != "" {
+		api.GET("/admin/records", adminBearerMiddleware(adminListRecords))
+		api.POST("/admin/records", adminBearerMiddleware(adminCreateRecord))
+		api.PUT("/admin/records/:id", adminBearerMiddleware(adminUpdateRecord))
+		api.DELETE("/admin/records/:id", adminBearerMiddleware(adminDeleteRecord))
+	}
 
 	host := config.API.IP + ":" + config.API.Port
 

--- a/types.go
+++ b/types.go
@@ -52,6 +52,12 @@ type httpapi struct {
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+	Admin               adminconfig
+}
+
+// Admin API config
+type adminconfig struct {
+	Token string
 }
 
 // Logging config
@@ -67,6 +73,16 @@ type acmedb struct {
 	DB *sql.DB
 }
 
+// DNSRecord represents a managed DNS record
+type DNSRecord struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Value   string `json:"value"`
+	TTL     int    `json:"ttl"`
+	Created int64  `json:"created"`
+}
+
 type database interface {
 	Init(string, string) error
 	Register(cidrslice) (ACMETxt, error)
@@ -78,4 +94,9 @@ type database interface {
 	Close()
 	Lock()
 	Unlock()
+	CreateRecord(DNSRecord) error
+	GetRecord(id string) (DNSRecord, error)
+	ListRecords(filterType, filterName string) ([]DNSRecord, error)
+	UpdateRecord(DNSRecord) error
+	DeleteRecord(id string) error
 }

--- a/validation.go
+++ b/validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net"
 	"regexp"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
@@ -43,6 +45,35 @@ func validTXT(s string) bool {
 func correctPassword(pw string, hash string) bool {
 	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(pw)); err == nil {
 		return true
+	}
+	return false
+}
+
+func validRecordType(typ string) bool {
+	switch typ {
+	case "A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA", "PTR":
+		return true
+	}
+	return false
+}
+
+func validTTL(ttl int) bool {
+	return ttl >= 1 && ttl <= 86400
+}
+
+func validRecordValue(rtype, value string) bool {
+	if value == "" {
+		return false
+	}
+	switch rtype {
+	case "A":
+		ip := net.ParseIP(value)
+		return ip != nil && ip.To4() != nil && !strings.Contains(value, ":")
+	case "AAAA":
+		ip := net.ParseIP(value)
+		return ip != nil && ip.To4() == nil
+	case "CNAME", "MX", "NS", "PTR", "SRV", "TXT", "CAA":
+		return true // non-empty check handled above; structural validation deferred to dns.NewRR
 	}
 	return false
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -110,6 +110,71 @@ func TestCorrectPassword(t *testing.T) {
 	}
 }
 
+func TestValidRecordType(t *testing.T) {
+	valid := []string{"A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA", "PTR"}
+	for _, rt := range valid {
+		if !validRecordType(rt) {
+			t.Errorf("expected %s to be valid", rt)
+		}
+	}
+	invalid := []string{"SOA", "AXFR", "ANY", "", "a", "aaaa"}
+	for _, rt := range invalid {
+		if validRecordType(rt) {
+			t.Errorf("expected %s to be invalid", rt)
+		}
+	}
+}
+
+func TestValidTTL(t *testing.T) {
+	valid := []int{1, 60, 300, 3600, 86400}
+	for _, ttl := range valid {
+		if !validTTL(ttl) {
+			t.Errorf("expected TTL %d to be valid", ttl)
+		}
+	}
+	invalid := []int{0, -1, 86401, 999999}
+	for _, ttl := range invalid {
+		if validTTL(ttl) {
+			t.Errorf("expected TTL %d to be invalid", ttl)
+		}
+	}
+}
+
+func TestValidRecordValue(t *testing.T) {
+	cases := []struct {
+		rtype string
+		value string
+		valid bool
+	}{
+		{"A", "1.2.3.4", true},
+		{"A", "256.1.1.1", false},
+		{"A", "not-an-ip", false},
+		{"A", "::ffff:1.2.3.4", false},
+		{"AAAA", "2001:db8::1", true},
+		{"AAAA", "1.2.3.4", false},
+		{"CNAME", "example.com", true},
+		{"CNAME", "", false},
+		{"MX", "mail.example.com", true},
+		{"MX", "", false},
+		{"NS", "ns1.example.com", true},
+		{"NS", "", false},
+		{"TXT", "any text value here", true},
+		{"TXT", "", false},
+		{"SRV", "_sip._tcp.example.com", true},
+		{"SRV", "", false},
+		{"CAA", "0 issue \"letsencrypt.org\"", true},
+		{"CAA", "", false},
+		{"PTR", "host.example.com", true},
+		{"PTR", "", false},
+	}
+	for _, tc := range cases {
+		got := validRecordValue(tc.rtype, tc.value)
+		if got != tc.valid {
+			t.Errorf("validRecordValue(%q, %q) = %v, want %v", tc.rtype, tc.value, got, tc.valid)
+		}
+	}
+}
+
 func TestGetValidCIDRMasks(t *testing.T) {
 	for i, test := range []struct {
 		input  cidrslice


### PR DESCRIPTION
## Summary

- Adds `[api.admin]` config section with bearer token authentication
- New `dns_records` table with full CRUD: `GET/POST /admin/records`, `PUT/DELETE /admin/records/:id`
- Supported record types: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA, PTR
- DNS server falls through to the `dns_records` table when no static/ACME records match a query
- Record names normalized to lowercase FQDN (trailing dot) on ingress via `toFQDN()` for consistent storage and lookup
- Admin routes only registered when `[api.admin].token` is non-empty (disabled by default)
- CORS extended to allow `PUT` and `DELETE` methods + `Authorization` and existing API key headers
- Structural RR validation via `probeRR()` before storage (catches malformed MX/SRV/CNAME/etc.)
- Composite index on `dns_records(name, type)` for efficient DNS lookups
- `DBVersion` bumped to 2 with `handleDBUpgradeTo2` migration
- `adminUpdateRecord` fetches the updated record via `GetRecord(id)` (single-indexed query) instead of a full table scan, eliminating O(N) cost and the TOCTOU window on concurrent deletes
- Authoritative Answer (AA) bit set on DNS responses served from managed records

## Test Plan

- [x] `go test ./...` passes
- [x] `go build ./...` builds cleanly
- [x] `POST /admin/records` with a valid bearer token creates a record (201)
- [x] `GET /admin/records` without token returns 401
- [x] `GET /admin/records?type=A` filters by record type
- [x] DNS query for a managed record returns the correct answer
- [x] Admin routes absent (404) when `token = ""` in config
- [x] `PUT /admin/records/:id` response preserves original `created` timestamp