### PR TITLE
fix: security hardening and HA deployment guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+
+## Unreleased
+
+### Breaking Changes
+- `corsorigins` default changed from `["*"]` to `[]` (deny all cross-origin by default).
+  If you rely on the default wildcard CORS behavior, explicitly set `corsorigins = ["*"]` in your config.
+
+### Security
+- Fixed SQL injection pattern in `NewTXTValuesInTransaction` (defense-in-depth, input was already sanitized)
+- Raised bcrypt cost factor from 10 to 12
+- Added per-IP rate limiting on `/register` endpoint (`register_ratelimit` config option)
+- `jsonError` now uses `json.Marshal` to safely encode error messages
+
 - v0.18.0:
   - Switched to go 1.24
 - v0.17.1:

--- a/api.go
+++ b/api.go
@@ -333,6 +333,7 @@ type rateLimiter struct {
 	buckets map[string]*rateBucket
 	limit   int
 	window  time.Duration
+	done    chan struct{}
 }
 
 func newRateLimiter(limit int) *rateLimiter {
@@ -340,6 +341,7 @@ func newRateLimiter(limit int) *rateLimiter {
 		buckets: make(map[string]*rateBucket),
 		limit:   limit,
 		window:  time.Minute,
+		done:    make(chan struct{}),
 	}
 	go rl.cleanup()
 	return rl
@@ -362,16 +364,27 @@ func (rl *rateLimiter) allow(ip string) bool {
 }
 
 func (rl *rateLimiter) cleanup() {
-	for range time.Tick(10 * time.Minute) {
-		rl.mu.Lock()
-		now := time.Now()
-		for ip, b := range rl.buckets {
-			if now.After(b.resetAt) {
-				delete(rl.buckets, ip)
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			now := time.Now()
+			for ip, b := range rl.buckets {
+				if now.After(b.resetAt) {
+					delete(rl.buckets, ip)
+				}
 			}
+			rl.mu.Unlock()
+		case <-rl.done:
+			return
 		}
-		rl.mu.Unlock()
 	}
+}
+
+func (rl *rateLimiter) stop() {
+	close(rl.done)
 }
 
 func rateLimitMiddleware(rl *rateLimiter, next httprouter.Handle) httprouter.Handle {

--- a/api.go
+++ b/api.go
@@ -7,13 +7,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 	"io"
-	"net/http"
-	"strings"
-	"time"
 )
 
 //go:embed openapi.json
@@ -316,4 +319,85 @@ func adminDeleteRecord(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// rateBucket holds a per-IP request count and reset time.
+type rateBucket struct {
+	count   int
+	resetAt time.Time
+}
+
+// rateLimiter is an in-memory token bucket rate limiter keyed by source IP.
+type rateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*rateBucket
+	limit   int
+	window  time.Duration
+}
+
+func newRateLimiter(limit int) *rateLimiter {
+	rl := &rateLimiter{
+		buckets: make(map[string]*rateBucket),
+		limit:   limit,
+		window:  time.Minute,
+	}
+	go rl.cleanup()
+	return rl
+}
+
+func (rl *rateLimiter) allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	b, ok := rl.buckets[ip]
+	if !ok || now.After(b.resetAt) {
+		rl.buckets[ip] = &rateBucket{count: 1, resetAt: now.Add(rl.window)}
+		return true
+	}
+	if b.count >= rl.limit {
+		return false
+	}
+	b.count++
+	return true
+}
+
+func (rl *rateLimiter) cleanup() {
+	for range time.Tick(10 * time.Minute) {
+		rl.mu.Lock()
+		now := time.Now()
+		for ip, b := range rl.buckets {
+			if now.After(b.resetAt) {
+				delete(rl.buckets, ip)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func rateLimitMiddleware(rl *rateLimiter, next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if rl == nil {
+			next(w, r, ps)
+			return
+		}
+		ip := r.RemoteAddr
+		if Config.API.UseHeader {
+			ips := getIPListFromHeader(r.Header.Get(Config.API.HeaderName))
+			if len(ips) > 0 {
+				ip = ips[0]
+			}
+		} else {
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err == nil {
+				ip = host
+			}
+		}
+		if !rl.allow(ip) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write(jsonError("rate_limit_exceeded"))
+			return
+		}
+		next(w, r, ps)
+	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -621,6 +621,7 @@ func TestRegisterRateLimit(t *testing.T) {
 	Config.API.HeaderName = "X-Forwarded-For"
 
 	limiter := newRateLimiter(Config.API.RegisterRateLimit)
+	defer limiter.stop()
 
 	api2 := httprouter.New()
 	api2.POST("/register", rateLimitMiddleware(limiter, webRegisterPost))

--- a/api_test.go
+++ b/api_test.go
@@ -614,6 +614,30 @@ func TestAdminWrongToken(t *testing.T) {
 	e.GET("/admin/records").WithHeader("Authorization", "Bearer wrong-token").Expect().Status(http.StatusUnauthorized)
 }
 
+func TestRegisterRateLimit(t *testing.T) {
+	// Use a very low limit to trigger rate limiting quickly
+	Config.API.RegisterRateLimit = 2
+	Config.API.UseHeader = true
+	Config.API.HeaderName = "X-Forwarded-For"
+
+	limiter := newRateLimiter(Config.API.RegisterRateLimit)
+
+	api2 := httprouter.New()
+	api2.POST("/register", rateLimitMiddleware(limiter, webRegisterPost))
+	c := cors.New(cors.Options{AllowedOrigins: []string{"*"}, AllowedMethods: []string{"GET", "POST"}})
+	server2 := httptest.NewServer(c.Handler(api2))
+	defer server2.Close()
+	e2 := getExpect(t, server2)
+
+	// First two should succeed
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusCreated)
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusCreated)
+	// Third from same IP should be rate limited
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusTooManyRequests)
+	// Different IP should still work
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.2").Expect().Status(http.StatusCreated)
+}
+
 func TestAdminCreateRecordInvalidValue(t *testing.T) {
 	_, e := setupAdminRouter(t, "test-token")
 	payload := map[string]interface{}{

--- a/config.cfg
+++ b/config.cfg
@@ -46,9 +46,9 @@ acme_cache_dir = "api-certs"
 # optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
 notification_email = ""
 # CORS AllowOrigins, wildcards can be used
-corsorigins = [
-    "*"
-]
+# WARNING: empty list denies all cross-origin requests (secure default)
+# Set explicitly for browser-based clients, e.g.: corsorigins = ["https://admin.example.com"]
+corsorigins = []
 # use HTTP header to get the client ip
 use_header = false
 # header name to pull the ip address / list of ip addresses from

--- a/config.cfg
+++ b/config.cfg
@@ -53,6 +53,8 @@ corsorigins = []
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+# max registrations per minute per source IP (0 = unlimited)
+register_ratelimit = 10
 
 # Admin API — leave token empty to disable admin endpoints
 [api.admin]

--- a/db.go
+++ b/db.go
@@ -179,14 +179,19 @@ func (d *acmedb) handleDBUpgradeTo1() error {
 
 // Create two rows for subdomain to the txt table
 func (d *acmedb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
-	instr := "INSERT INTO txt (Subdomain, LastUpdate) values($1, 0)"
+	stmt := "INSERT INTO txt (Subdomain, LastUpdate) values($1, 0)"
 	if Config.Database.Engine == "sqlite3" {
-		instr = getSQLiteStmt(instr)
+		stmt = getSQLiteStmt(stmt)
 	}
-	if _, err := tx.Exec(instr, subdomain); err != nil {
+	ps, err := tx.Prepare(stmt)
+	if err != nil {
 		return err
 	}
-	if _, err := tx.Exec(instr, subdomain); err != nil {
+	defer closeStatement(ps)
+	if _, err := ps.Exec(subdomain); err != nil {
+		return err
+	}
+	if _, err := ps.Exec(subdomain); err != nil {
 		return err
 	}
 	return nil

--- a/db.go
+++ b/db.go
@@ -179,11 +179,17 @@ func (d *acmedb) handleDBUpgradeTo1() error {
 
 // Create two rows for subdomain to the txt table
 func (d *acmedb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
-	var err error
-	instr := fmt.Sprintf("INSERT INTO txt (Subdomain, LastUpdate) values('%s', 0)", subdomain)
-	_, _ = tx.Exec(instr)
-	_, _ = tx.Exec(instr)
-	return err
+	instr := "INSERT INTO txt (Subdomain, LastUpdate) values($1, 0)"
+	if Config.Database.Engine == "sqlite3" {
+		instr = getSQLiteStmt(instr)
+	}
+	if _, err := tx.Exec(instr, subdomain); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(instr, subdomain); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
@@ -201,7 +207,7 @@ func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
 	}()
 	a := newACMETxt()
 	a.AllowFrom = afrom.ValidEntries()
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(a.Password), 10)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(a.Password), 12)
 	regSQL := `
     INSERT INTO records(
         Username,

--- a/docs/ha-deployment.md
+++ b/docs/ha-deployment.md
@@ -1,0 +1,132 @@
+# acme-dns High Availability Deployment Guide
+
+## Model: Active-Active with Shared PostgreSQL
+
+Multiple acme-dns instances run simultaneously behind a load balancer. All instances share one PostgreSQL database. The HTTP API is stateless — no session affinity is required. DNS can be distributed across instances using round-robin NS records.
+
+## Prerequisites
+
+- PostgreSQL 14+ (primary/replica HA managed externally, e.g. Patroni, RDS Multi-AZ, Cloud SQL HA)
+- A load balancer for HTTP: HAProxy, nginx, or cloud LB (AWS ALB, GCP HTTPS LB)
+- Optional: pgBouncer for connection pooling under high registration volume
+- At least 2 acme-dns instances
+
+## Database Configuration
+
+All instances share the same connection string:
+
+```toml
+[database]
+engine = "postgres"
+connection = "postgres://acmedns:password@pg-primary.internal/acmedns_db"
+```
+
+Recommended PostgreSQL settings (`postgresql.conf`):
+```
+max_connections = 100          # scale with instance count
+idle_in_transaction_session_timeout = 30s
+```
+
+Database migrations run automatically on startup. Run only **one instance first** on initial deploy, then start the others once the schema is ready.
+
+## Instance Configuration
+
+Each instance has an identical `config.cfg` except for `[api].ip` (bind address per host). Key settings:
+
+```toml
+[database]
+engine = "postgres"
+connection = "postgres://acmedns:password@pg-primary.internal/acmedns_db"
+
+[api]
+ip = "0.0.0.0"     # or specific interface
+port = "443"
+tls = "cert"       # manage certs externally in HA setups
+```
+
+Do **not** use `tls = "letsencrypt"` on multiple instances — each would race for certificate renewal. Use a shared cert (wildcard or SAN) or terminate TLS at the load balancer.
+
+## DNS Load Balancing
+
+Configure multiple A records for the acme-dns NS hostname with a low TTL (60s) for fast failover:
+
+```
+auth.example.org.  60  IN  A  203.0.113.1   ; instance 1
+auth.example.org.  60  IN  A  203.0.113.2   ; instance 2
+```
+
+Resolvers will round-robin between instances for DNS queries.
+
+## HTTP API Load Balancing
+
+### HAProxy Example
+
+```haproxy
+frontend acmedns-api
+    bind *:443 ssl crt /etc/ssl/acmedns.pem
+    default_backend acmedns-instances
+
+backend acmedns-instances
+    balance roundrobin
+    option httpchk GET /health
+    http-check expect status 200
+    server acmedns1 10.0.0.1:443 check ssl verify none
+    server acmedns2 10.0.0.2:443 check ssl verify none
+```
+
+### pgBouncer (optional, for high registration volume)
+
+```ini
+[databases]
+acmedns_db = host=pg-primary.internal port=5432 dbname=acmedns_db
+
+[pgbouncer]
+pool_mode = transaction
+max_client_conn = 200
+default_pool_size = 20
+```
+
+Then point acme-dns at pgBouncer instead of PostgreSQL directly:
+```toml
+connection = "postgres://acmedns:password@pgbouncer.internal:5432/acmedns_db"
+```
+
+## Health Check
+
+The `/health` endpoint returns HTTP 200 when the instance is ready. Use it for:
+- Load balancer health probes (see HAProxy config above)
+- Kubernetes readiness/liveness probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 3
+  periodSeconds: 5
+```
+
+## Failure Modes
+
+| Failure | Impact | Recovery |
+|---------|--------|----------|
+| One instance dies | DNS queries and HTTP API handled by remaining instances | Automatic — load balancer stops routing to failed instance |
+| PostgreSQL unreachable | HTTP API returns 500; DNS continues serving cached records from resolver caches | Restore PostgreSQL; instances reconnect automatically on next request |
+| PostgreSQL replica failover | Transient errors during failover window (~30s for Patroni) | Use pgBouncer to buffer connections; instances retry |
+
+## Upgrade Procedure (Rolling Restart)
+
+1. Run DB migrations once: `acme-dns -c config.cfg --migrate` (or start one instance; migrations are idempotent)
+2. Stop and restart instances one at a time, verifying `/health` before moving to the next
+3. DNS resolvers cache responses — TTL (default 60s for NS records) means no visible downtime
+
+## Security Notes in HA
+
+- Rate limiting (`register_ratelimit`) is per-instance, per-IP (in-memory). In active-active, a single IP can register up to `register_ratelimit * N` times per minute across N instances. For stricter enforcement, place rate limiting at the load balancer (HAProxy `stick-tables`, nginx `limit_req`).
+- All instances share the same `[api.admin].token` — rotate it by updating all instances' configs and restarting them.

--- a/main.go
+++ b/main.go
@@ -126,8 +126,12 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsServers []*DNSServer)
 		// Logwriter for saner log output
 		c.Log = stdlog.New(logWriter, "", 0)
 	}
+	var registerLimiter *rateLimiter
+	if config.API.RegisterRateLimit > 0 {
+		registerLimiter = newRateLimiter(config.API.RegisterRateLimit)
+	}
 	if !config.API.DisableRegistration {
-		api.POST("/register", webRegisterPost)
+		api.POST("/register", rateLimitMiddleware(registerLimiter, webRegisterPost))
 	}
 	api.POST("/update", Auth(webUpdatePost))
 	api.GET("/health", healthCheck)

--- a/types.go
+++ b/types.go
@@ -52,6 +52,7 @@ type httpapi struct {
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+	RegisterRateLimit   int    `toml:"register_ratelimit"`
 	Admin               adminconfig
 }
 

--- a/util.go
+++ b/util.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"os"
 	"regexp"
@@ -14,7 +14,8 @@ import (
 )
 
 func jsonError(message string) []byte {
-	return []byte(fmt.Sprintf("{\"error\": \"%s\"}", message))
+	b, _ := json.Marshal(map[string]string{"error": message})
+	return b
 }
 
 func fileIsAccessible(fName string) bool {

--- a/util_test.go
+++ b/util_test.go
@@ -148,6 +148,23 @@ func TestPrepareConfig(t *testing.T) {
 	}
 }
 
+func TestJsonErrorWithSpecialChars(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"simple error", `{"error":"simple error"}`},
+		{`error with "quotes"`, `{"error":"error with \"quotes\""}`},
+		{"error with\nnewline", `{"error":"error with\nnewline"}`},
+	}
+	for _, tc := range cases {
+		got := string(jsonError(tc.input))
+		if got != tc.expected {
+			t.Errorf("jsonError(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
 func cleanupTmpFile(tmpFile string) {
 	if err := os.Remove(tmpFile); err != nil {
 		panic("Could not remove temporary file")


### PR DESCRIPTION
## Summary

- **SQL injection fix:** `NewTXTValuesInTransaction` now uses a parameterized query + prepared statement instead of `fmt.Sprintf` string interpolation (defense-in-depth — input was already sanitized)
- **bcrypt cost:** Raised from 10 to 12 (~300ms per registration, transparent to existing stored hashes)
- **`jsonError`:** Uses `json.Marshal` instead of `fmt.Sprintf` to safely encode error messages containing quotes or special characters
- **Rate limiting:** Per-IP in-memory token bucket on `/register`; configured via `register_ratelimit = 10` in `[api]` (0 = unlimited); returns HTTP 429 when exceeded
- **CORS default hardening:** `corsorigins` default changed from `["*"]` to `[]` — deny all cross-origin by default. **Breaking change** — documented in `CHANGELOG.md`
- **HA guide:** `docs/ha-deployment.md` — active-active deployment with shared PostgreSQL, HAProxy/pgBouncer examples, Kubernetes probes, failure modes table, rolling upgrade procedure

**Depends on:** #223

## Breaking Changes

`corsorigins` default is now `[]`. Deployments relying on the implicit `*` must explicitly set `corsorigins = ["*"]` in their config.

## Test Plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] `/register` returns 429 after exceeding `register_ratelimit` from same IP
- [ ] `/register` from a different IP still returns 201 after limit hit on another IP
- [ ] `jsonError` with a message containing `"quotes"` produces valid JSON
- [ ] Review `CHANGELOG.md` for breaking change note
- [ ] Review `docs/ha-deployment.md`