### PR TITLE
feat: Add OpenAPI 3.1 spec and MCP server binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-acme-dns
+./acme-dns
+./acme-dns-mcp
 acme-dns.db
 acme-dns.log
 .vagrant

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,14 @@ builds:
     goos:
       - linux
       - darwin
+  - id: acme-dns-mcp
+    main: ./cmd/acme-dns-mcp
+    binary: acme-dns-mcp
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     - Bearer token authentication for admin endpoints
     - Store custom DNS records in a database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
     - Comprehensive DNS record validation (type, value, TTL)
+    - OpenAPI 3.1 specification served at `GET /openapi.json`
+    - `acme-dns-mcp` binary: stdio MCP server exposing acme-dns as tools for MCP-compatible AI agents
   - Changed
     - DNS server now serves both challenge records and managed records from the database
     - FQDN normalization on ingress for consistency

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ For longer explanation of the underlying issue and other proposed solutions, see
 - Simplified DNS server, serving your ACME DNS challenges (TXT)
 - Custom records (have your required A, AAAA, NS, etc. records served)
 - Admin API for managing DNS records with Bearer token authentication
+- OpenAPI 3.1 specification served at `GET /openapi.json`
+- MCP server binary (`acme-dns-mcp`) exposing acme-dns as structured tools for MCP-compatible AI agents
 - HTTP API automatically acquires and uses Let's Encrypt TLS certificate
 - Limit /update API endpoint access to specific CIDR mask(s), defined in the /register request
 - Supports SQLite & PostgreSQL as DB backends
@@ -253,6 +255,91 @@ The method can be used to check readiness and/or liveness of the server. It will
 
 `GET /health`
 
+### OpenAPI specification
+
+A static OpenAPI 3.1 document describing every endpoint above (`/register`, `/update`, `/health`, and the admin record CRUD endpoints) is embedded in the binary and served without authentication:
+
+`GET /openapi.json`
+
+Point any OpenAPI-compatible tool (Swagger UI, Postman, code generators, etc.) at this URL to explore or generate a client for the API.
+
+## MCP Server
+
+`cmd/acme-dns-mcp` builds a separate binary, `acme-dns-mcp`, that exposes the acme-dns HTTP API as [Model Context Protocol](https://modelcontextprotocol.io) (MCP) tools over stdio, so MCP-compatible AI agents (Claude Desktop, Claude Code, etc.) can register subdomains, publish ACME challenge records, and manage DNS records on your behalf.
+
+It is a thin, stateless JSON-RPC 2.0 wrapper: every tool call becomes a single HTTP request against a running acme-dns instance (configured via `base_url`) and the HTTP response is translated back into an MCP tool result. It does not talk to the database or DNS server directly.
+
+### Installing
+
+`acme-dns-mcp` ships in the same release archive as `acme-dns` (see [Installation](#installation)). Download the archive for your platform from the [latest release](https://github.com/zpascal/acme-dns/releases/latest), extract it, and move the binary to a directory in your $PATH, for example:
+
+`sudo mv acme-dns-mcp /usr/local/bin`
+
+### Configuring
+
+Configuration is read from a TOML file, then overridden by environment variables. Both are optional — a missing config file is not an error, and any field can be supplied purely through the environment.
+
+- Default file location: `~/.acme-dns-mcp/config.toml`
+- Override the file location with `ACMEDNS_MCP_CONFIG=/path/to/config.toml`
+
+```toml
+# ~/.acme-dns-mcp/config.toml
+base_url = "https://auth.example.org"
+admin_token = "your-secret-admin-token-here"
+username = "c36f50e8-4632-44f0-83fe-e070fef28a10"
+password = "paasword"
+```
+
+| TOML key      | Environment variable  | Used by                                                                           |
+|---------------|-----------------------|-----------------------------------------------------------------------------------|
+| `base_url`    | `ACMEDNS_BASE_URL`    | All tools — the acme-dns instance to talk to                                      |
+| `admin_token` | `ACMEDNS_ADMIN_TOKEN` | `list_dns_records`, `create_dns_record`, `update_dns_record`, `delete_dns_record` |
+| `username`    | `ACMEDNS_USERNAME`    | `update_txt_record`                                                               |
+| `password`    | `ACMEDNS_PASSWORD`    | `update_txt_record`                                                               |
+
+Credentials are only ever read from this configuration — MCP tool arguments never accept a token, username, or password, so a malicious or careless prompt cannot exfiltrate credentials through tool call arguments.
+
+### Registering with an MCP client
+
+Most MCP clients (e.g. Claude Desktop, Claude Code) accept a `command`+`env` style server definition:
+
+```json
+{
+  "mcpServers": {
+    "acme-dns": {
+      "command": "/usr/local/bin/acme-dns-mcp",
+      "env": {
+        "ACMEDNS_BASE_URL": "https://auth.example.org",
+        "ACMEDNS_ADMIN_TOKEN": "your-secret-admin-token-here"
+      }
+    }
+  }
+}
+```
+
+### Available tools
+
+| Tool                 | Requires               | Arguments                                                         | Description                                                                    |
+|----------------------|------------------------|-------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `health_check`       | —                      | none                                                              | Checks that the acme-dns instance is reachable.                                |
+| `register_subdomain` | —                      | `allowfrom` (optional array of CIDRs)                             | Registers a new subdomain and returns credentials, mirroring `POST /register`. |
+| `update_txt_record`  | `username`, `password` | `subdomain` (required), `txt` (required, exactly 43 characters)   | Publishes an ACME challenge TXT value, mirroring `POST /update`.               |
+| `list_dns_records`   | `admin_token`          | `type`, `name` (both optional filters)                            | Lists managed DNS records, mirroring `GET /admin/records`.                     |
+| `create_dns_record`  | `admin_token`          | `name`, `type`, `value` (required), `ttl` (optional, default 300) | Creates a managed DNS record.                                                  |
+| `update_dns_record`  | `admin_token`          | `id`, `name`, `type`, `value` (required), `ttl` (optional)        | Updates a managed DNS record by ID.                                            |
+| `delete_dns_record`  | `admin_token`          | `id` (required)                                                   | Deletes a managed DNS record by ID.                                            |
+
+Tools that require `admin_token` or `username`/`password` return `{"error": "..."}` (with `isError: true`, see below) instead of making a request when the corresponding configuration is missing.
+
+### Error handling
+
+Every `tools/call` result carries an `isError` flag alongside its content, per the MCP specification:
+
+- **`isError: false`** — the underlying acme-dns API call succeeded (2xx); the content is the API's response.
+- **`isError: true`** — the acme-dns API rejected the request (e.g. `invalid_ttl`, `record_not_found`, `unauthorized`) or the required configuration was missing; the content carries the `{"error": "..."}` body so an MCP client can distinguish a failed operation from a successful one, rather than a failure being reported as an apparently-successful result.
+
+A JSON-RPC-level error (the `error` field on the response, separate from `isError`) is only used for protocol-level failures: an unknown tool name, an unreachable acme-dns instance, or a malformed request.
+
 ## Self-hosted
 
 You are encouraged to run your own acme-dns instance, because you are effectively authorizing the acme-dns server to act on your behalf in providing the answer to the challenging CA, making the instance able to request (and get issued) a TLS certificate for the domain that has CNAME pointing to it.
@@ -261,28 +348,19 @@ See the INSTALL section for information on how to do this.
 
 ## Installation
 
-1. Install [Go 1.24 or newer](https://golang.org/doc/install).
-2. Build acme-dns:
-
-   ```bash
-   git clone https://github.com/zpascal/acme-dns
-   cd acme-dns
-   export GOPATH=/tmp/acme-dns
-   go build
-   ```
-
-3. Move the built acme-dns binary to a directory in your $PATH, for example:
+1. Download the archive for your platform from the [latest release](https://github.com/zpascal/acme-dns/releases/latest) (e.g. `acme-dns_<version>_linux_amd64.tar.gz`, also available for `darwin_amd64`, `darwin_arm64`, `linux_arm64`, and `linux_386`). Each archive contains both the `acme-dns` server binary and the `acme-dns-mcp` binary (see [MCP Server](#mcp-server)).
+2. Extract the archive and move the acme-dns binary to a directory in your $PATH, for example:
    `sudo mv acme-dns /usr/local/bin`
-4. Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`, or a location specified with the `-c` flag.
-5. If your system has systemd, you can optionally install acme-dns as a service so that it will start on boot and be tracked by systemd. This also allows us to add the `CAP_NET_BIND_SERVICE` capability so that acme-dns can be run by a user other than root.
+3. Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`, or a location specified with the `-c` flag.
+4. If your system has systemd, you can optionally install acme-dns as a service so that it will start on boot and be tracked by systemd. This also allows us to add the `CAP_NET_BIND_SERVICE` capability so that acme-dns can be run by a user other than root.
    1. Make sure that you have moved the configuration file to `/etc/acme-dns/config.cfg` so that acme-dns can access it globally.
-   2. Move the acme-dns executable from `~/go/bin/acme-dns` to `/usr/local/bin/acme-dns` (Any location will work, just be sure to change `acme-dns.service` to match).
+   2. Make sure that the acme-dns executable is at `/usr/local/bin/acme-dns` (any location will work, just be sure to change `acme-dns.service` to match).
    3. Create a minimal acme-dns user: `sudo adduser --system --gecos "acme-dns Service" --disabled-password --group --home /var/lib/acme-dns acme-dns`.
    4. Move the systemd service unit from `acme-dns.service` to `/etc/systemd/system/acme-dns.service`.
    5. Reload systemd units: `sudo systemctl daemon-reload`.
    6. Enable acme-dns on boot: `sudo systemctl enable acme-dns.service`.
    7. Run acme-dns: `sudo systemctl start acme-dns.service`.
-6. If you did not install the systemd service, run `acme-dns`. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
+5. If you did not install the systemd service, run `acme-dns`. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
 
 ### Upgrading to v1.0.0
 

--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/subtle"
 	"database/sql"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,6 +35,9 @@ func buildCORSOptions(origins []string, methods, headers []string) cors.Options 
 	}
 	return opts
 }
+
+//go:embed openapi.json
+var openapiSpec []byte
 
 // toFQDN ensures a DNS name ends with a trailing dot for consistent storage and lookup.
 func toFQDN(name string) string {
@@ -161,6 +165,12 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusOK)
+}
+
+func serveOpenAPI(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(openapiSpec)
 }
 
 // adminRecordRequest is the request body for creating/updating a DNS record

--- a/api_test.go
+++ b/api_test.go
@@ -71,6 +71,7 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 	))
 	api.POST("/register", webRegisterPost)
 	api.GET("/health", healthCheck)
+	api.GET("/openapi.json", serveOpenAPI)
 	if noauth {
 		api.POST("/update", noAuth(webUpdatePost))
 	} else {
@@ -440,6 +441,17 @@ func TestApiHealthCheck(t *testing.T) {
 	defer server.Close()
 	e := getExpect(t, server)
 	e.GET("/health").Expect().Status(http.StatusOK)
+}
+
+func TestOpenAPIEndpoint(t *testing.T) {
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	resp := e.GET("/openapi.json").Expect()
+	resp.Status(http.StatusOK)
+	resp.Header("Content-Type").Contains("application/json")
+	resp.JSON().Object().ContainsKey("openapi")
 }
 
 func setupAdminRouter(t *testing.T, token string) (*httptest.Server, *httpexpect.Expect) {

--- a/cmd/acme-dns-mcp/config.go
+++ b/cmd/acme-dns-mcp/config.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+type mcpConfig struct {
+	BaseURL    string `toml:"base_url"`
+	AdminToken string `toml:"admin_token"`
+	Username   string `toml:"username"`
+	Password   string `toml:"password"`
+}
+
+// loadConfig reads from a TOML file (if path non-empty) or from env vars
+func loadConfig(path string) mcpConfig {
+	var cfg mcpConfig
+	if path != "" {
+		if _, err := toml.DecodeFile(path, &cfg); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "acme-dns-mcp: failed to parse config file %s: %v\n", path, err)
+		}
+	}
+	if v := os.Getenv("ACMEDNS_BASE_URL"); v != "" {
+		cfg.BaseURL = v
+	}
+	if v := os.Getenv("ACMEDNS_ADMIN_TOKEN"); v != "" {
+		cfg.AdminToken = v
+	}
+	if v := os.Getenv("ACMEDNS_USERNAME"); v != "" {
+		cfg.Username = v
+	}
+	if v := os.Getenv("ACMEDNS_PASSWORD"); v != "" {
+		cfg.Password = v
+	}
+	return cfg
+}

--- a/cmd/acme-dns-mcp/main.go
+++ b/cmd/acme-dns-mcp/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// maxRPCLineSize bounds a single JSON-RPC request line. bufio.Scanner's default
+// (bufio.MaxScanTokenSize, 64KB) is too small for tool calls carrying larger
+// payloads (e.g. batches of DNS records) and fails silently when exceeded.
+const maxRPCLineSize = 10 * 1024 * 1024
+
+type jsonRPCRequest struct {
+	JSONRPC string                 `json:"jsonrpc"`
+	ID      interface{}            `json:"id"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   interface{} `json:"error,omitempty"`
+}
+
+// handleRequest processes one decoded JSON-RPC request and returns the response to encode.
+func handleRequest(cfg mcpConfig, req jsonRPCRequest) jsonRPCResponse {
+	var resp jsonRPCResponse
+	resp.JSONRPC = "2.0"
+	resp.ID = req.ID
+
+	switch req.Method {
+	case "initialize":
+		resp.Result = map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "acme-dns-mcp", "version": "1.0.0"},
+		}
+	case "tools/list":
+		resp.Result = map[string]interface{}{"tools": listTools()}
+	case "tools/call":
+		toolName, _ := req.Params["name"].(string)
+		args, _ := req.Params["arguments"].(map[string]interface{})
+		if args == nil {
+			args = map[string]interface{}{}
+		}
+		result, isError, err := callTool(cfg, toolName, args)
+		if err != nil {
+			resp.Error = map[string]interface{}{"code": -32000, "message": err.Error()}
+		} else {
+			resultJSON, _ := json.Marshal(result)
+			resp.Result = map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": string(resultJSON)},
+				},
+				"isError": isError,
+			}
+		}
+	default:
+		resp.Error = map[string]interface{}{"code": -32601, "message": fmt.Sprintf("method not found: %s", req.Method)}
+	}
+
+	return resp
+}
+
+func main() {
+	cfgPath := filepath.Join(os.Getenv("HOME"), ".acme-dns-mcp", "config.toml")
+	if v := os.Getenv("ACMEDNS_MCP_CONFIG"); v != "" {
+		cfgPath = v
+	}
+	cfg := loadConfig(cfgPath)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxRPCLineSize)
+	encoder := json.NewEncoder(os.Stdout)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var req jsonRPCRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		_ = encoder.Encode(handleRequest(cfg, req))
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "acme-dns-mcp: stdin read error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/acme-dns-mcp/mcp_test.go
+++ b/cmd/acme-dns-mcp/mcp_test.go
@@ -1,0 +1,543 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	require := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	require(os.Setenv("ACMEDNS_BASE_URL", "https://acmedns.example.com"))
+	require(os.Setenv("ACMEDNS_ADMIN_TOKEN", "secret-admin"))
+	require(os.Setenv("ACMEDNS_USERNAME", "user-uuid"))
+	require(os.Setenv("ACMEDNS_PASSWORD", "user-pass"))
+	defer func() {
+		_ = os.Unsetenv("ACMEDNS_BASE_URL")
+		_ = os.Unsetenv("ACMEDNS_ADMIN_TOKEN")
+		_ = os.Unsetenv("ACMEDNS_USERNAME")
+		_ = os.Unsetenv("ACMEDNS_PASSWORD")
+	}()
+
+	cfg := loadConfig("")
+	if cfg.BaseURL != "https://acmedns.example.com" {
+		t.Errorf("BaseURL: got %q", cfg.BaseURL)
+	}
+	if cfg.AdminToken != "secret-admin" {
+		t.Errorf("AdminToken: got %q", cfg.AdminToken)
+	}
+	if cfg.Username != "user-uuid" {
+		t.Errorf("Username: got %q", cfg.Username)
+	}
+	if cfg.Password != "user-pass" {
+		t.Errorf("Password: got %q", cfg.Password)
+	}
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	f, err := os.CreateTemp("", "mcp-cfg-*.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+	if _, err := f.WriteString(`
+base_url = "https://local.example.com"
+admin_token = "file-admin"
+username = "file-user"
+password = "file-pass"
+`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := loadConfig(f.Name())
+	if cfg.BaseURL != "https://local.example.com" {
+		t.Errorf("BaseURL from file: got %q", cfg.BaseURL)
+	}
+}
+
+func TestToolHealthCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL}
+	result, isError, err := callTool(cfg, "health_check", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("health_check failed: %v", err)
+	}
+	if isError {
+		t.Errorf("expected isError=false, got true (result: %v)", result)
+	}
+	if result["status"] != "ok" {
+		t.Errorf("expected status ok, got %v", result)
+	}
+}
+
+func TestToolListTools(t *testing.T) {
+	tools := listTools()
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	for _, expected := range []string{"register_subdomain", "update_txt_record", "list_dns_records", "create_dns_record", "update_dns_record", "delete_dns_record", "health_check"} {
+		if !names[expected] {
+			t.Errorf("missing tool: %s", expected)
+		}
+	}
+}
+
+func TestToolListRecords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/admin/records" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"test-id","name":"example.com","type":"A","value":"1.2.3.4","ttl":300,"created":0}]`))
+		}
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	result, isError, err := callTool(cfg, "list_dns_records", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("list_dns_records failed: %v", err)
+	}
+	if isError {
+		t.Errorf("expected isError=false, got true (result: %v)", result)
+	}
+	records, ok := result["records"]
+	if !ok {
+		t.Fatalf("expected 'records' key in result, got %v", result)
+	}
+	arr, ok := records.([]interface{})
+	if !ok {
+		t.Fatalf("expected records to be array, got %T", records)
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(arr))
+	}
+}
+
+func TestToolListRecordsEscapesQueryParams(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	_, _, err := callTool(cfg, "list_dns_records", map[string]interface{}{"name": "foo&type=TXT#frag"})
+	if err != nil {
+		t.Fatalf("list_dns_records failed: %v", err)
+	}
+	q, err := url.ParseQuery(gotQuery)
+	if err != nil {
+		t.Fatalf("server received unparseable query %q: %v", gotQuery, err)
+	}
+	if got := q.Get("name"); got != "foo&type=TXT#frag" {
+		t.Errorf("expected name filter to survive intact, got %q (raw query: %q)", got, gotQuery)
+	}
+	if q.Get("type") != "" {
+		t.Errorf("unescaped input injected an unintended type param: %q", gotQuery)
+	}
+}
+
+func TestToolUpdateRecordEscapesID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"weird"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	_, _, err := callTool(cfg, "update_dns_record", map[string]interface{}{
+		"id": "abc?admin=true", "name": "x.example.com", "type": "A", "value": "1.2.3.4",
+	})
+	if err != nil {
+		t.Fatalf("update_dns_record failed: %v", err)
+	}
+	if gotPath != "/admin/records/abc?admin=true" {
+		t.Errorf("expected id to be escaped into the literal path, server saw path %q", gotPath)
+	}
+}
+
+func TestToolCreateRecordSurfacesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_ttl"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	result, isError, err := callTool(cfg, "create_dns_record", map[string]interface{}{
+		"name": "x.example.com", "type": "A", "value": "1.2.3.4", "ttl": 0,
+	})
+	if err != nil {
+		t.Fatalf("create_dns_record returned a transport error: %v", err)
+	}
+	if !isError {
+		t.Fatalf("expected isError=true for a 400 response, got false (result: %v)", result)
+	}
+	if result["error"] != "invalid_ttl" {
+		t.Errorf("expected the acme-dns error body to be surfaced, got %v", result)
+	}
+}
+
+func TestToolMissingAdminTokenIsError(t *testing.T) {
+	cfg := mcpConfig{BaseURL: "http://unused.invalid"}
+	for _, name := range []string{"list_dns_records", "create_dns_record", "update_dns_record", "delete_dns_record"} {
+		result, isError, err := callTool(cfg, name, map[string]interface{}{"id": "x"})
+		if err != nil {
+			t.Fatalf("%s: unexpected transport error: %v", name, err)
+		}
+		if !isError {
+			t.Errorf("%s: expected isError=true when admin_token is not configured", name)
+		}
+		if result["error"] != "admin_token not configured" {
+			t.Errorf("%s: expected admin_token error, got %v", name, result)
+		}
+	}
+}
+
+func TestToolHealthCheckUnhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL}
+	result, isError, err := callTool(cfg, "health_check", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("health_check returned a transport error: %v", err)
+	}
+	if !isError {
+		t.Errorf("expected isError=true for a non-200 response, got false (result: %v)", result)
+	}
+	if result["status"] != "unhealthy" {
+		t.Errorf("expected status unhealthy, got %v", result)
+	}
+	if result["code"] != http.StatusServiceUnavailable {
+		t.Errorf("expected code %d, got %v", http.StatusServiceUnavailable, result["code"])
+	}
+}
+
+func TestToolRegister(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/register" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"username":"u","password":"p","subdomain":"s","fulldomain":"s.example.org","allowfrom":[]}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL}
+	result, isError, err := callTool(cfg, "register_subdomain", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("register_subdomain failed: %v", err)
+	}
+	if isError {
+		t.Errorf("expected isError=false, got true (result: %v)", result)
+	}
+	if result["subdomain"] != "s" {
+		t.Errorf("expected subdomain 's', got %v", result)
+	}
+}
+
+func TestToolRegisterSurfacesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_allowfrom_cidr"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL}
+	result, isError, err := callTool(cfg, "register_subdomain", map[string]interface{}{"allowfrom": []interface{}{"not-a-cidr"}})
+	if err != nil {
+		t.Fatalf("register_subdomain returned a transport error: %v", err)
+	}
+	if !isError {
+		t.Fatalf("expected isError=true for a 400 response, got false (result: %v)", result)
+	}
+	if result["error"] != "invalid_allowfrom_cidr" {
+		t.Errorf("expected the acme-dns error body to be surfaced, got %v", result)
+	}
+}
+
+func TestToolUpdateTXT(t *testing.T) {
+	var gotUser, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser = r.Header.Get("X-Api-User")
+		gotKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"txt":"___validation_token_received_from_the_ca___"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, Username: "user-uuid", Password: "user-pass"}
+	result, isError, err := callTool(cfg, "update_txt_record", map[string]interface{}{
+		"subdomain": "s", "txt": "___validation_token_received_from_the_ca___",
+	})
+	if err != nil {
+		t.Fatalf("update_txt_record failed: %v", err)
+	}
+	if isError {
+		t.Errorf("expected isError=false, got true (result: %v)", result)
+	}
+	if gotUser != "user-uuid" || gotKey != "user-pass" {
+		t.Errorf("expected credentials to be forwarded as headers, got user=%q key=%q", gotUser, gotKey)
+	}
+}
+
+func TestToolUpdateTXTMissingCredentials(t *testing.T) {
+	cfg := mcpConfig{BaseURL: "http://unused.invalid"}
+	result, isError, err := callTool(cfg, "update_txt_record", map[string]interface{}{"subdomain": "s", "txt": "x"})
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	if !isError {
+		t.Errorf("expected isError=true when username/password are not configured")
+	}
+	if result["error"] != "username and password not configured" {
+		t.Errorf("expected credentials error, got %v", result)
+	}
+}
+
+func TestToolUpdateTXTSurfacesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad_txt"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, Username: "u", Password: "p"}
+	result, isError, err := callTool(cfg, "update_txt_record", map[string]interface{}{"subdomain": "s", "txt": "too-short"})
+	if err != nil {
+		t.Fatalf("update_txt_record returned a transport error: %v", err)
+	}
+	if !isError {
+		t.Fatalf("expected isError=true for a 400 response, got false (result: %v)", result)
+	}
+	if result["error"] != "bad_txt" {
+		t.Errorf("expected the acme-dns error body to be surfaced, got %v", result)
+	}
+}
+
+func TestToolDeleteRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/admin/records/test-id" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	result, isError, err := callTool(cfg, "delete_dns_record", map[string]interface{}{"id": "test-id"})
+	if err != nil {
+		t.Fatalf("delete_dns_record failed: %v", err)
+	}
+	if isError {
+		t.Errorf("expected isError=false, got true (result: %v)", result)
+	}
+	if result["status"] != "deleted" {
+		t.Errorf("expected status deleted, got %v", result)
+	}
+}
+
+func TestToolDeleteRecordNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"record_not_found"}`))
+	}))
+	defer srv.Close()
+
+	cfg := mcpConfig{BaseURL: srv.URL, AdminToken: "test-token"}
+	result, isError, err := callTool(cfg, "delete_dns_record", map[string]interface{}{"id": "missing"})
+	if err != nil {
+		t.Fatalf("delete_dns_record returned a transport error: %v", err)
+	}
+	if !isError {
+		t.Fatalf("expected isError=true for a 404 response, got false (result: %v)", result)
+	}
+	if result["status"] != "error" || result["code"] != http.StatusNotFound {
+		t.Errorf("expected status error with code 404, got %v", result)
+	}
+}
+
+func TestToolUpdateRecordMissingID(t *testing.T) {
+	cfg := mcpConfig{BaseURL: "http://unused.invalid", AdminToken: "test-token"}
+	result, isError, err := callTool(cfg, "update_dns_record", map[string]interface{}{"name": "x", "type": "A", "value": "1.2.3.4"})
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	if !isError {
+		t.Errorf("expected isError=true when id is missing")
+	}
+	if result["error"] != "id is required" {
+		t.Errorf("expected id-required error, got %v", result)
+	}
+}
+
+func TestToolHealthCheckTransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close() // closed immediately: nothing is listening on this address anymore
+
+	cfg := mcpConfig{BaseURL: unreachable}
+	result, isError, err := callTool(cfg, "health_check", map[string]interface{}{})
+	if err == nil {
+		t.Fatalf("expected a transport error when the server is unreachable, got result=%v isError=%v", result, isError)
+	}
+}
+
+func TestCallToolUnknown(t *testing.T) {
+	cfg := mcpConfig{BaseURL: "http://unused.invalid"}
+	result, isError, err := callTool(cfg, "not_a_real_tool", map[string]interface{}{})
+	if err == nil {
+		t.Fatalf("expected a transport-level error for an unknown tool, got result=%v isError=%v", result, isError)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for an unknown tool, got %v", result)
+	}
+}
+
+func TestAsResultMap(t *testing.T) {
+	if m := asResultMap(map[string]interface{}{"a": 1}); m["a"] != 1 {
+		t.Errorf("expected map passthrough, got %v", m)
+	}
+	arr := []interface{}{"x", "y"}
+	wrapped := asResultMap(arr)
+	if got, ok := wrapped["result"].([]interface{}); !ok || len(got) != 2 {
+		t.Errorf("expected non-map results wrapped under 'result', got %v", wrapped)
+	}
+}
+
+func TestLoadConfigMalformedFile(t *testing.T) {
+	f, err := os.CreateTemp("", "mcp-cfg-bad-*.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+	if _, err := f.WriteString("this is not valid = = toml"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A malformed file must not panic and must fall back to zero-value fields
+	// (env vars still apply on top, exercised separately by TestLoadConfigFromEnv).
+	cfg := loadConfig(f.Name())
+	if cfg.BaseURL != "" || cfg.AdminToken != "" {
+		t.Errorf("expected zero-value config from a malformed file, got %+v", cfg)
+	}
+}
+
+func TestHandleRequestInitialize(t *testing.T) {
+	resp := handleRequest(mcpConfig{}, jsonRPCRequest{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a result map, got %v", resp.Result)
+	}
+	if result["protocolVersion"] != "2024-11-05" {
+		t.Errorf("expected protocolVersion 2024-11-05, got %v", result["protocolVersion"])
+	}
+	if resp.Error != nil {
+		t.Errorf("expected no error, got %v", resp.Error)
+	}
+}
+
+func TestHandleRequestToolsList(t *testing.T) {
+	resp := handleRequest(mcpConfig{}, jsonRPCRequest{JSONRPC: "2.0", ID: 2, Method: "tools/list"})
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a result map, got %v", resp.Result)
+	}
+	tools, ok := result["tools"].([]tool)
+	if !ok || len(tools) != 7 {
+		t.Errorf("expected 7 tools, got %v", result["tools"])
+	}
+}
+
+func TestHandleRequestUnknownMethod(t *testing.T) {
+	resp := handleRequest(mcpConfig{}, jsonRPCRequest{JSONRPC: "2.0", ID: 3, Method: "not/a/method"})
+	errMap, ok := resp.Error.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected an error map, got %v", resp.Error)
+	}
+	if errMap["code"] != -32601 {
+		t.Errorf("expected JSON-RPC method-not-found code -32601, got %v", errMap["code"])
+	}
+}
+
+func TestHandleRequestToolsCallSuccessAndFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	cfg := mcpConfig{BaseURL: srv.URL}
+
+	resp := handleRequest(cfg, jsonRPCRequest{
+		JSONRPC: "2.0", ID: 4, Method: "tools/call",
+		Params: map[string]interface{}{"name": "health_check", "arguments": map[string]interface{}{}},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected protocol error: %v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a result map, got %v", resp.Result)
+	}
+	if result["isError"] != false {
+		t.Errorf("expected isError=false for a successful tool call, got %v", result["isError"])
+	}
+
+	// An unknown tool name is a protocol-level error (JSON-RPC error field, not isError).
+	resp2 := handleRequest(cfg, jsonRPCRequest{
+		JSONRPC: "2.0", ID: 5, Method: "tools/call",
+		Params: map[string]interface{}{"name": "does_not_exist"},
+	})
+	if resp2.Error == nil {
+		t.Fatalf("expected a protocol error for an unknown tool name, got result=%v", resp2.Result)
+	}
+}
+
+func TestHandleRequestToolsCallMissingArguments(t *testing.T) {
+	// No "arguments" key at all — should default to an empty map, not panic.
+	resp := handleRequest(mcpConfig{BaseURL: "http://unused.invalid", AdminToken: "t"}, jsonRPCRequest{
+		JSONRPC: "2.0", ID: 6, Method: "tools/call",
+		Params: map[string]interface{}{"name": "delete_dns_record"},
+	})
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a result map, got %v", resp.Result)
+	}
+	if result["isError"] != true {
+		t.Errorf("expected isError=true for delete_dns_record without an id, got %v", result["isError"])
+	}
+}

--- a/cmd/acme-dns-mcp/tools.go
+++ b/cmd/acme-dns-mcp/tools.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// tool describes one MCP tool
+type tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+func listTools() []tool {
+	return []tool{
+		{
+			Name:        "health_check",
+			Description: "Check if the acme-dns server is reachable and healthy.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		},
+		{
+			Name:        "register_subdomain",
+			Description: "Register a new subdomain and receive credentials (username, password, subdomain) for ACME DNS challenge delegation.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"allowfrom":{"type":"array","items":{"type":"string"},"description":"Optional CIDR ranges allowed to use this account"}}}`),
+		},
+		{
+			Name:        "update_txt_record",
+			Description: "Update the ACME TXT challenge record for a registered subdomain. Requires username and password from registration.",
+			InputSchema: json.RawMessage(`{"type":"object","required":["subdomain","txt"],"properties":{"subdomain":{"type":"string","description":"UUID subdomain from registration"},"txt":{"type":"string","description":"Exactly 43-character ACME challenge token"}}}`),
+		},
+		{
+			Name:        "list_dns_records",
+			Description: "List all managed DNS records. Optionally filter by type (e.g. A) or name.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"type":{"type":"string"},"name":{"type":"string"}}}`),
+		},
+		{
+			Name:        "create_dns_record",
+			Description: "Create a new managed DNS record. Supported types: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA, PTR.",
+			InputSchema: json.RawMessage(`{"type":"object","required":["name","type","value"],"properties":{"name":{"type":"string"},"type":{"type":"string"},"value":{"type":"string"},"ttl":{"type":"integer","default":300}}}`),
+		},
+		{
+			Name:        "update_dns_record",
+			Description: "Update an existing managed DNS record by ID.",
+			InputSchema: json.RawMessage(`{"type":"object","required":["id","name","type","value"],"properties":{"id":{"type":"string"},"name":{"type":"string"},"type":{"type":"string"},"value":{"type":"string"},"ttl":{"type":"integer"}}}`),
+		},
+		{
+			Name:        "delete_dns_record",
+			Description: "Delete a managed DNS record by ID.",
+			InputSchema: json.RawMessage(`{"type":"object","required":["id"],"properties":{"id":{"type":"string"}}}`),
+		},
+	}
+}
+
+// callTool executes a tool by name. It returns the result payload, whether the
+// result represents a tool-level failure (isError, e.g. the acme-dns API rejected
+// the request), and a transport/protocol-level error (e.g. the HTTP call itself
+// failed or the tool name is unknown).
+func callTool(cfg mcpConfig, name string, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	switch name {
+	case "health_check":
+		return toolHealthCheck(cfg)
+	case "register_subdomain":
+		return toolRegister(cfg, args)
+	case "update_txt_record":
+		return toolUpdateTXT(cfg, args)
+	case "list_dns_records":
+		return toolListRecords(cfg, args)
+	case "create_dns_record":
+		return toolCreateRecord(cfg, args)
+	case "update_dns_record":
+		return toolUpdateRecord(cfg, args)
+	case "delete_dns_record":
+		return toolDeleteRecord(cfg, args)
+	}
+	return nil, false, fmt.Errorf("unknown tool: %s", name)
+}
+
+// isSuccessStatus reports whether an HTTP status code represents a successful response.
+func isSuccessStatus(status int) bool {
+	return status >= 200 && status < 300
+}
+
+// asResultMap normalizes a decoded JSON body into a map, wrapping non-object
+// payloads (e.g. a bare JSON array) so callers always get a map back.
+func asResultMap(result interface{}) map[string]interface{} {
+	if m, ok := result.(map[string]interface{}); ok {
+		return m
+	}
+	return map[string]interface{}{"result": result}
+}
+
+// adminAuthHeaders returns the Authorization header for admin endpoints, or an
+// error result map (with isError=true) if no admin token is configured.
+func adminAuthHeaders(cfg mcpConfig) (map[string]string, map[string]interface{}) {
+	if cfg.AdminToken == "" {
+		return nil, map[string]interface{}{"error": "admin_token not configured"}
+	}
+	return map[string]string{"Authorization": "Bearer " + cfg.AdminToken}, nil
+}
+
+func doRequest(cfg mcpConfig, method, path string, body interface{}, headers map[string]string) (interface{}, int, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, err
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, cfg.BaseURL+path, bodyReader)
+	if err != nil {
+		return nil, 0, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result == nil {
+		result = map[string]interface{}{}
+	}
+	return result, resp.StatusCode, nil
+}
+
+func toolHealthCheck(cfg mcpConfig) (map[string]interface{}, bool, error) {
+	_, status, err := doRequest(cfg, "GET", "/health", nil, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if status == http.StatusOK {
+		return map[string]interface{}{"status": "ok"}, false, nil
+	}
+	return map[string]interface{}{"status": "unhealthy", "code": status}, true, nil
+}
+
+func toolRegister(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	result, status, err := doRequest(cfg, "POST", "/register", args, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	return asResultMap(result), !isSuccessStatus(status), nil
+}
+
+func toolUpdateTXT(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	if cfg.Username == "" || cfg.Password == "" {
+		return map[string]interface{}{"error": "username and password not configured"}, true, nil
+	}
+	headers := map[string]string{
+		"X-Api-User": cfg.Username,
+		"X-Api-Key":  cfg.Password,
+	}
+	result, status, err := doRequest(cfg, "POST", "/update", args, headers)
+	if err != nil {
+		return nil, false, err
+	}
+	return asResultMap(result), !isSuccessStatus(status), nil
+}
+
+func toolListRecords(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	headers, errResult := adminAuthHeaders(cfg)
+	if errResult != nil {
+		return errResult, true, nil
+	}
+	q := url.Values{}
+	if t, ok := args["type"].(string); ok && t != "" {
+		q.Set("type", t)
+	}
+	if n, ok := args["name"].(string); ok && n != "" {
+		q.Set("name", n)
+	}
+	path := "/admin/records"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	result, status, err := doRequest(cfg, "GET", path, nil, headers)
+	if err != nil {
+		return nil, false, err
+	}
+	if !isSuccessStatus(status) {
+		// Error bodies from the admin API are JSON objects (e.g. {"error":"db_error"}),
+		// not arrays — surface them directly instead of nesting under "records".
+		return asResultMap(result), true, nil
+	}
+	// GET /admin/records returns a JSON array on success — wrap it for uniform map return
+	return map[string]interface{}{"records": result}, false, nil
+}
+
+func toolCreateRecord(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	headers, errResult := adminAuthHeaders(cfg)
+	if errResult != nil {
+		return errResult, true, nil
+	}
+	result, status, err := doRequest(cfg, "POST", "/admin/records", args, headers)
+	if err != nil {
+		return nil, false, err
+	}
+	return asResultMap(result), !isSuccessStatus(status), nil
+}
+
+func toolUpdateRecord(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	headers, errResult := adminAuthHeaders(cfg)
+	if errResult != nil {
+		return errResult, true, nil
+	}
+	id, _ := args["id"].(string)
+	if id == "" {
+		return map[string]interface{}{"error": "id is required"}, true, nil
+	}
+	result, status, err := doRequest(cfg, "PUT", "/admin/records/"+url.PathEscape(id), args, headers)
+	if err != nil {
+		return nil, false, err
+	}
+	return asResultMap(result), !isSuccessStatus(status), nil
+}
+
+func toolDeleteRecord(cfg mcpConfig, args map[string]interface{}) (map[string]interface{}, bool, error) {
+	headers, errResult := adminAuthHeaders(cfg)
+	if errResult != nil {
+		return errResult, true, nil
+	}
+	id, _ := args["id"].(string)
+	if id == "" {
+		return map[string]interface{}{"error": "id is required"}, true, nil
+	}
+	_, status, err := doRequest(cfg, "DELETE", "/admin/records/"+url.PathEscape(id), nil, headers)
+	if err != nil {
+		return nil, false, err
+	}
+	if status == http.StatusNoContent {
+		return map[string]interface{}{"status": "deleted"}, false, nil
+	}
+	return map[string]interface{}{"status": "error", "code": status}, true, nil
+}

--- a/config.cfg
+++ b/config.cfg
@@ -58,6 +58,7 @@ register_ratelimit = 10
 
 # Admin API — leave token empty to disable admin endpoints or remove the section from your config
 #[api.admin]
+# token = "your-secret-admin-token-here"
 #token = ""
 
 [logconfig]

--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsServers []*DNSServer)
 	}
 	api.POST("/update", Auth(webUpdatePost))
 	api.GET("/health", healthCheck)
+	api.GET("/openapi.json", serveOpenAPI)
 	if config.API.Admin.Token != "" {
 		api.GET("/admin/records", adminBearerMiddleware(adminListRecords))
 		api.POST("/admin/records", adminBearerMiddleware(adminCreateRecord))

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,188 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "acme-dns",
+    "version": "1.0.0",
+    "description": "Simplified DNS server with HTTP API for ACME DNS challenge automation and general DNS record management."
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiUser": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-User",
+        "description": "UUIDv4 username obtained from /register"
+      },
+      "ApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key",
+        "description": "40-character base64url password obtained from /register"
+      },
+      "AdminBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Admin token configured in [api.admin].token"
+      }
+    },
+    "schemas": {
+      "Registration": {
+        "type": "object",
+        "properties": {
+          "username": { "type": "string", "format": "uuid" },
+          "password": { "type": "string" },
+          "fulldomain": { "type": "string" },
+          "subdomain": { "type": "string" },
+          "allowfrom": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "TxtUpdate": {
+        "type": "object",
+        "required": ["subdomain", "txt"],
+        "properties": {
+          "subdomain": { "type": "string", "description": "UUID subdomain from registration" },
+          "txt": { "type": "string", "minLength": 43, "maxLength": 43, "description": "ACME challenge token (exactly 43 characters)" }
+        }
+      },
+      "DNSRecord": {
+        "type": "object",
+        "required": ["name", "type", "value"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string", "description": "Fully qualified domain name, e.g. sub.example.com" },
+          "type": { "type": "string", "enum": ["A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA", "PTR"] },
+          "value": { "type": "string" },
+          "ttl": { "type": "integer", "minimum": 1, "maximum": 86400, "default": 300 },
+          "created": { "type": "integer", "description": "Unix timestamp" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/register": {
+      "post": {
+        "summary": "Register a new subdomain",
+        "description": "Creates a new user account with a UUID subdomain for ACME DNS challenge delegation. Optionally restrict access to specific IP CIDRs.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "allowfrom": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of CIDR ranges allowed to use this account, e.g. [\"192.168.1.0/24\"]"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account created",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Registration" } } }
+          },
+          "400": { "description": "Invalid CIDR or malformed JSON", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "summary": "Update ACME TXT record",
+        "description": "Updates the TXT record for your subdomain with a new ACME challenge token. Requires X-Api-User and X-Api-Key headers from registration.",
+        "security": [{ "ApiUser": [], "ApiKey": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TxtUpdate" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "TXT record updated", "content": { "application/json": { "schema": { "type": "object", "properties": { "txt": { "type": "string" } } } } } },
+          "400": { "description": "Invalid subdomain or TXT value" },
+          "401": { "description": "Invalid credentials or IP not allowed" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "description": "Returns 200 OK when the server is ready. Use for liveness and readiness probes.",
+        "responses": {
+          "200": { "description": "Server is healthy" }
+        }
+      }
+    },
+    "/admin/records": {
+      "get": {
+        "summary": "List DNS records",
+        "description": "Returns all managed DNS records. Filter by type and/or name using query parameters.",
+        "security": [{ "AdminBearer": [] }],
+        "parameters": [
+          { "name": "type", "in": "query", "schema": { "type": "string" }, "description": "Filter by record type, e.g. A" },
+          { "name": "name", "in": "query", "schema": { "type": "string" }, "description": "Filter by exact domain name" }
+        ],
+        "responses": {
+          "200": { "description": "List of records", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DNSRecord" } } } } },
+          "401": { "description": "Invalid or missing admin token" }
+        }
+      },
+      "post": {
+        "summary": "Create DNS record",
+        "description": "Creates a new managed DNS record. Supported types: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA, PTR.",
+        "security": [{ "AdminBearer": [] }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DNSRecord" } } }
+        },
+        "responses": {
+          "201": { "description": "Record created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DNSRecord" } } } },
+          "400": { "description": "Invalid record type, value, or TTL" },
+          "401": { "description": "Invalid or missing admin token" }
+        }
+      }
+    },
+    "/admin/records/{id}": {
+      "put": {
+        "summary": "Update DNS record",
+        "description": "Updates an existing managed DNS record by ID.",
+        "security": [{ "AdminBearer": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DNSRecord" } } }
+        },
+        "responses": {
+          "200": { "description": "Record updated", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DNSRecord" } } } },
+          "400": { "description": "Invalid record data" },
+          "401": { "description": "Invalid or missing admin token" }
+        }
+      },
+      "delete": {
+        "summary": "Delete DNS record",
+        "description": "Deletes a managed DNS record by ID.",
+        "security": [{ "AdminBearer": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "204": { "description": "Record deleted" },
+          "401": { "description": "Invalid or missing admin token" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Static OpenAPI 3.1 spec embedded in binary, served at `GET /openapi.json` (no auth required)
- Documents all endpoints: `POST /register`, `POST /update`, `GET /health`, and the admin record CRUD endpoints
- New `cmd/acme-dns-mcp/` binary: stdio-based MCP server wrapping the acme-dns HTTP API as structured tools
- MCP tools: `register_subdomain`, `update_txt_record`, `list_dns_records`, `create_dns_record`, `update_dns_record`, `delete_dns_record`, `health_check`
- Config loaded from `~/.acme-dns-mcp/config.toml` or env vars (`ACMEDNS_BASE_URL`, `ACMEDNS_ADMIN_TOKEN`, etc.)
- Credentials never passed as tool arguments — config only
- `.goreleaser.yml` updated to build and publish `acme-dns-mcp` alongside `acme-dns`

## Test Plan

- [x] `go test -race ./...` passes
- [x] `go build ./...` builds cleanly
- [x] `GET /openapi.json` returns valid OpenAPI 3.1 JSON
- [x] MCP `health_check` tool returns `{"status":"ok"}` against a running instance
- [x] MCP `list_dns_records` returns `{"records":[...]}` with admin token configured
- [x] Missing credentials return `{"error":"admin_token not configured"}`

All items above were verified end-to-end against a locally running acme-dns instance with `cmd/acme-dns-mcp` communicating over stdio.
