### PR TITLE
fix: Security hardening and HA deployment guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
-- v0.22.0:
+- v1.0.0:
   - NOTE: Admin API is disabled by default. Set an admin token in `[api.admin]` section to enable it.
+  - Breaking Changes
+    - `corsorigins` default changed from `["*"]` to `[]` (deny all cross-origin by default).
+      If you rely on the default wildcard CORS behavior, explicitly set `corsorigins = ["*"]` in your config.
   - New
     - Admin API for managing DNS records (CRUD operations)
     - Bearer token authentication for admin endpoints
-    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
+    - Store custom DNS records in a database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
     - Comprehensive DNS record validation (type, value, TTL)
   - Changed
     - DNS server now serves both challenge records and managed records from database
     - FQDN normalization on ingress for consistency
     - Added database index for efficient record lookups
+    - Raised bcrypt cost factor from 10 to 12
+    - `jsonError` now uses `json.Marshal` to safely encode error messages
+  - Security
+    - Fixed SQL injection pattern in `NewTXTValuesInTransaction` (defense-in-depth, input was already sanitized)
+    - Added per-IP rate limiting on `/register` endpoint (`register_ratelimit` config option)
 - v0.21.6:
   - Changed
     - Update base image to golang:1.26-alpine3.23
@@ -59,76 +67,6 @@
 - v0.18.1:
   - Changed
     - Dependencies update
-- v0.22.0:
-  - NOTE: Admin API is disabled by default. Set an admin token in `[api.admin]` section to enable it.
-  - New
-    - Admin API for managing DNS records (CRUD operations)
-    - Bearer token authentication for admin endpoints
-    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
-    - Comprehensive DNS record validation (type, value, TTL)
-  - Changed
-    - DNS server now serves both challenge records and managed records from database
-    - FQDN normalization on ingress for consistency
-    - Added database index for efficient record lookups
-- v0.21.6:
-  - Changed
-    - Update base image to golang:1.26-alpine3.23
-    - Dependencies update
-- v0.21.5:
-  - Changed
-    - Remove asciicast link from README
-    - Dependencies update
-- v0.21.4:
-  - Changed
-    - Add token to checkout step in workflow
-    - Fix tag command in monthly patch release workflow
-    - Refactor Git configuration and tag creation step
-    - Dependencies update
-- v0.21.3:
-  - Changed
-    - Update the Go version and add GH action for the automatic release handling
-    - Dependencies update
-- v0.21.2:
-  - Changed
-    - Dependencies update
-- v0.21.1:
-  - Changed
-    - Dependencies update
-- v0.21.0:
-  - Changed
-    - Update the Lego version
-    - Dependencies update
-- v0.20.0:
-  - New
-    - Add the Codeowners file
-  - Changed
-    - Update the Go version
-    - Dependencies update
-- v0.19.1:
-  - Changed
-    - Update the Alpine version
-    - Dependencies update
-- v0.19.0:
-  - Changed
-    - Update the Alpine version
-    - Dependencies update
-- v0.18.2:
-  - Changed
-    - Bump the used version
-    - Dependencies update
-- v0.18.1:
-  - Changed
-    - Dependencies update
-- v0.22.0:
-  - New
-    - Admin API for managing DNS records (CRUD operations)
-    - Bearer token authentication for admin endpoints
-    - Store custom DNS records in database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
-    - Comprehensive DNS record validation (type, value, TTL)
-  - Changed
-    - DNS server now serves both challenge records and managed records from database
-    - FQDN normalization on ingress for consistency
-    - Added database index for efficient record lookups
 - v0.18.0:
   - Switched to go 1.24
 - v0.17.1:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ With the credentials, you can update the TXT response in the service to match th
 }
 ```
 
+#### Rate limiting
+
+`/register` is rate limited per source IP (`register_ratelimit` in `[api]`, default `10` registrations per minute; `0` disables the limit). The limit is enforced in-memory per instance, keyed by the client IP (or the first address from `header_name` when `use_header = true`). Exceeding it returns:
+
+`Status: 429 Too Many Requests`
+
+```json
+{
+  "error": "rate_limit_exceeded"
+}
+```
+
 ### Update endpoint
 
 The method allows you to update the TXT answer contents of your unique subdomain. Usually carried automatically by automated ACME client.
@@ -270,6 +282,14 @@ See the INSTALL section for information on how to do this.
    6. Enable acme-dns on boot: `sudo systemctl enable acme-dns.service`.
    7. Run acme-dns: `sudo systemctl start acme-dns.service`.
 6. If you did not install the systemd service, run `acme-dns`. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
+
+### Upgrading to v1.0.0
+
+**Breaking Changes:**
+
+- **CORS Configuration**: The default `corsorigins` has changed from `["*"]` (allow all) to `[]` (deny all). This is a security-focused change to deny cross-origin requests by default.
+  - If you rely on the previous wildcard CORS behavior, explicitly set `corsorigins = ["*"]` in your `[api]` config section.
+  - If you're integrating acme-dns with a web application on a different origin, configure `corsorigins` with the specific origins you trust.
 
 ### Using Docker
 
@@ -394,13 +414,14 @@ acme_cache_dir = "api-certs"
 # optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
 notification_email = ""
 # CORS AllowOrigins, wildcards can be used
-corsorigins = [
-    "*"
-]
+# NOTE: v1.0.0+ defaults to [] (deny all). Set to ["*"] to allow all origins.
+corsorigins = []
 # use HTTP header to get the client ip
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+# max registrations per minute per source IP on the /register endpoint (0 = unlimited)
+register_ratelimit = 10
 # Admin API — leave token empty to disable admin endpoints
 # token = "your-secret-admin-token-here"
 token = ""
@@ -416,6 +437,149 @@ logtype = "stdout"
 logformat = "text"
 ```
 
+## High Availability Deployment
+
+Multiple acme-dns instances run simultaneously behind a load balancer. All instances share one PostgreSQL database. The HTTP API is stateless — no session affinity is required. DNS can be distributed across instances using round-robin NS records.
+
+### Prerequisites
+
+- PostgreSQL 14+ (primary/replica HA, e.g. PostgreSQL cluster, RDS Multi-AZ, Cloud SQL HA)
+- A load balancer for HTTP: Nginx, Apache2, or cloud ALB (AWS ELB, GCP HTTPS LB)
+- At least 2 acme-dns instances
+
+### HA Database Configuration
+
+All instances share the same connection string:
+
+```toml
+[database]
+engine = "postgres"
+connection = "postgres://acmedns:password@pg-primary.internal/acmedns_db"
+```
+
+Recommended PostgreSQL settings (`postgresql.conf`):
+```
+max_connections = 100          # scale with instance count
+idle_in_transaction_session_timeout = 30s
+```
+
+Database migrations run automatically on startup. Run only **one instance first** on initial deploy, then start the others once the schema is ready.
+
+### HA Instance Configuration
+
+Each instance has an identical `config.cfg` except for `[api].ip` (bind address per host). Key settings:
+
+```toml
+[database]
+engine = "postgres"
+connection = "postgres://acmedns:password@pg-primary.internal/acmedns_db"
+
+[api]
+ip = "0.0.0.0"     # or specific interface
+port = "443"
+tls = "cert"       # manage certs externally in HA setups
+```
+
+Do **not** use `tls = "letsencrypt"` on multiple instances — each would race for certificate renewal. Use a shared cert (wildcard or SAN) or terminate TLS at the load balancer.
+
+### DNS Load Balancing
+
+Configure multiple A records for the acme-dns NS hostname with a low TTL (60s) for fast failover:
+
+```
+auth.example.org.  60  IN  A  203.0.113.1   ; instance 1
+auth.example.org.  60  IN  A  203.0.113.2   ; instance 2
+```
+
+Resolvers will round-robin between instances for DNS queries.
+
+### HTTP API Load Balancing
+
+#### Nginx Example
+
+```nginx
+upstream acmedns_instances {
+    server 10.0.0.1:443;
+    server 10.0.0.2:443;
+}
+
+server {
+    listen 443 ssl;
+    ssl_certificate     /etc/ssl/acmedns.pem;
+    ssl_certificate_key /etc/ssl/acmedns.key;
+
+    location /health {
+        proxy_pass https://acmedns_instances/health;
+        access_log off;
+    }
+
+    location / {
+        proxy_pass https://acmedns_instances;
+        proxy_ssl_verify off;
+    }
+}
+```
+
+#### Apache2 Example
+
+```apache
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/acmedns.pem
+    SSLCertificateKeyFile /etc/ssl/acmedns.key
+
+    <Proxy "balancer://acmedns-instances">
+        BalancerMember "https://10.0.0.1:443"
+        BalancerMember "https://10.0.0.2:443"
+        ProxySet lbmethod=byrequests
+    </Proxy>
+
+    ProxyPreserveHost On
+    ProxyPass "/" "balancer://acmedns-instances/"
+    ProxyPassReverse "/" "balancer://acmedns-instances/"
+</VirtualHost>
+```
+
+### HA Health Check
+
+The `/health` endpoint returns HTTP 200 when the instance is ready. Use it for:
+- Load balancer health probes (see Nginx/Apache2 config above)
+- Kubernetes readiness/liveness probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 3
+  periodSeconds: 5
+```
+
+### Failure Modes
+
+| Failure | Impact | Recovery |
+|---------|--------|----------|
+| One instance dies | DNS queries and HTTP API handled by remaining instances | Automatic — load balancer stops routing to failed instance |
+| PostgreSQL unreachable | HTTP API returns 500; DNS continues serving cached records from resolver caches | Restore PostgreSQL; instances reconnect automatically on next request |
+| PostgreSQL replica failover | Transient errors during failover window | Instances retry automatically on next request |
+
+### Upgrade Procedure (Rolling Restart)
+
+1. Start one instance first; migrations are idempotent and run automatically
+2. Stop and restart instances one at a time, verifying `/health` before moving to the next
+3. DNS resolvers cache responses — TTL (default 60s for NS records) means no visible downtime
+
+### Security Notes in HA
+
+- Rate limiting (`register_ratelimit`) is per-instance, per-IP (in-memory). In active-active, a single IP can register up to `register_ratelimit * N` times per minute across N instances. For stricter enforcement, place rate limiting at the load balancer (nginx `limit_req`).
+- All instances share the same `[api.admin].token` — rotate it by updating all instances' configs and restarting them.
+
 ## HTTPS API
 
 The RESTful acme-dns API can be exposed over HTTPS in two ways:
@@ -425,13 +589,13 @@ The RESTful acme-dns API can be exposed over HTTPS in two ways:
 2. Using `tls = "cert"` and providing your own HTTPS certificate chain and
    private key with `tls_cert_fullchain` and `tls_cert_privkey`.
 
-Where possible the first option is recommended. This is the easiest and safest
+Where possible, the first option is recommended. This is the easiest and safest
 way to have acme-dns expose its API over HTTPS.
 
 **Warning**: If you choose to use `tls = "cert"` you must take care that the
 certificate _does not expire_! If it does and the ACME client you use to issue the
-certificate depends on the ACME DNS API to update TXT records you will be stuck
-in a position where the API certificate has expired but it can't be renewed
+certificate depends on the ACME DNS API to update TXT records, you will be stuck
+in a position where the API certificate has expired, but it can't be renewed
 because the ACME client will refuse to connect to the ACME DNS API it needs to
 use for the renewal.
 
@@ -449,7 +613,7 @@ use for the renewal.
 ### Authentication hooks
 
 - acme-dns-client with Certbot authentication hook: [https://github.com/acme-dns/acme-dns-client](https://github.com/acme-dns/acme-dns-client)
-- Certbot authentication hook in Python: [https://github.com/zpascal/acme-dns-certbot-joohoi](https://github.com/zpascal/acme-dns-certbot-joohoi)
+- Certbot authentication hook in Python: [https://github.com/joohoi/acme-dns-certbot-joohoi](https://github.com/joohoi/acme-dns-certbot-joohoi)
 - Certbot authentication hook in Go: [https://github.com/koesie10/acme-dns-certbot-hook](https://github.com/koesie10/acme-dns-certbot-hook)
 
 ### Libraries

--- a/api.go
+++ b/api.go
@@ -6,15 +6,34 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	"github.com/miekg/dns"
+	"github.com/rs/cors"
 	log "github.com/sirupsen/logrus"
 	"io"
-	"net/http"
-	"strings"
-	"time"
 )
+
+// buildCORSOptions returns cors.Options that deny all cross-origin requests when
+// origins is empty, or allow exactly the listed origins otherwise.
+func buildCORSOptions(origins []string, methods, headers []string) cors.Options {
+	opts := cors.Options{
+		AllowedMethods: methods,
+		AllowedHeaders: headers,
+	}
+	if len(origins) == 0 {
+		opts.AllowOriginFunc = func(string) bool { return false }
+	} else {
+		opts.AllowedOrigins = origins
+	}
+	return opts
+}
 
 // toFQDN ensures a DNS name ends with a trailing dot for consistent storage and lookup.
 func toFQDN(name string) string {
@@ -218,6 +237,7 @@ func adminCreateRecord(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 		_, _ = w.Write(jsonError("invalid_record_value"))
 		return
 	}
+
 	ttl := req.TTL
 	if ttl == 0 {
 		ttl = 300
@@ -338,4 +358,98 @@ func adminDeleteRecord(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// rateBucket holds a per-IP request count and reset time.
+type rateBucket struct {
+	count   int
+	resetAt time.Time
+}
+
+// rateLimiter is an in-memory token bucket rate limiter keyed by source IP.
+type rateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*rateBucket
+	limit   int
+	window  time.Duration
+	done    chan struct{}
+}
+
+func newRateLimiter(limit int) *rateLimiter {
+	rl := &rateLimiter{
+		buckets: make(map[string]*rateBucket),
+		limit:   limit,
+		window:  time.Minute,
+		done:    make(chan struct{}),
+	}
+	go rl.cleanup()
+	return rl
+}
+
+func (rl *rateLimiter) allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	b, ok := rl.buckets[ip]
+	if !ok || now.After(b.resetAt) {
+		rl.buckets[ip] = &rateBucket{count: 1, resetAt: now.Add(rl.window)}
+		return true
+	}
+	if b.count >= rl.limit {
+		return false
+	}
+	b.count++
+	return true
+}
+
+func (rl *rateLimiter) cleanup() {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			now := time.Now()
+			for ip, b := range rl.buckets {
+				if now.After(b.resetAt) {
+					delete(rl.buckets, ip)
+				}
+			}
+			rl.mu.Unlock()
+		case <-rl.done:
+			return
+		}
+	}
+}
+
+func (rl *rateLimiter) stop() {
+	close(rl.done)
+}
+
+func rateLimitMiddleware(rl *rateLimiter, next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if rl == nil {
+			next(w, r, ps)
+			return
+		}
+		ip := r.RemoteAddr
+		if Config.API.UseHeader {
+			ips := getIPListFromHeader(r.Header.Get(Config.API.HeaderName))
+			if len(ips) > 0 {
+				ip = ips[0]
+			}
+		} else {
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err == nil {
+				ip = host
+			}
+		}
+		if !rl.allow(ip) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write(jsonError("rate_limit_exceeded"))
+			return
+		}
+		next(w, r, ps)
+	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -55,7 +55,7 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 		Domain:      "",
 		Port:        "8080",
 		TLS:         "none",
-		CorsOrigins: []string{"*"},
+		CorsOrigins: Config.API.CorsOrigins,
 		UseHeader:   true,
 		HeaderName:  "X-Forwarded-For",
 	}
@@ -64,12 +64,11 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 		Database: dbcfg,
 	}
 	Config = dnscfg
-	c := cors.New(cors.Options{
-		AllowedOrigins:     Config.API.CorsOrigins,
-		AllowedMethods:     []string{"GET", "POST"},
-		OptionsPassthrough: false,
-		Debug:              Config.General.Debug,
-	})
+	c := cors.New(buildCORSOptions(
+		Config.API.CorsOrigins,
+		[]string{"GET", "POST"},
+		nil,
+	))
 	api.POST("/register", webRegisterPost)
 	api.GET("/health", healthCheck)
 	if noauth {
@@ -600,6 +599,70 @@ func TestAdminUpdateRecord(t *testing.T) {
 func TestAdminWrongToken(t *testing.T) {
 	_, e := setupAdminRouter(t, "correct-token")
 	e.GET("/admin/records").WithHeader("Authorization", "Bearer wrong-token").Expect().Status(http.StatusUnauthorized)
+}
+
+func TestRegisterRateLimit(t *testing.T) {
+	// Use a very low limit to trigger rate limiting quickly
+	Config.API.RegisterRateLimit = 2
+	Config.API.UseHeader = true
+	Config.API.HeaderName = "X-Forwarded-For"
+
+	limiter := newRateLimiter(Config.API.RegisterRateLimit)
+	defer limiter.stop()
+
+	api2 := httprouter.New()
+	api2.POST("/register", rateLimitMiddleware(limiter, webRegisterPost))
+	c := cors.New(cors.Options{AllowedOrigins: []string{"*"}, AllowedMethods: []string{"GET", "POST"}})
+	server2 := httptest.NewServer(c.Handler(api2))
+	defer server2.Close()
+	e2 := getExpect(t, server2)
+
+	// First two should succeed
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusCreated)
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusCreated)
+	// Third from same IP should be rate limited
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().Status(http.StatusTooManyRequests)
+	// Different IP should still work
+	e2.POST("/register").WithHeader("X-Forwarded-For", "10.0.0.2").Expect().Status(http.StatusCreated)
+}
+
+func TestCORSEmptyOriginsDeniesCrossOrigin(t *testing.T) {
+	// corsorigins = [] must deny all cross-origin requests (no ACAO header).
+	Config.API.CorsOrigins = []string{}
+	t.Cleanup(func() { Config.API.CorsOrigins = nil })
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+
+	resp := e.GET("/health").WithHeader("Origin", "https://evil.com").Expect().Status(http.StatusOK).Raw()
+	if resp.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin header with empty corsorigins, got %q",
+			resp.Header.Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestCORSConfiguredOriginAllowed(t *testing.T) {
+	// A listed origin must receive the Access-Control-Allow-Origin header.
+	Config.API.CorsOrigins = []string{"https://trusted.example.com"}
+	t.Cleanup(func() { Config.API.CorsOrigins = nil })
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+
+	resp := e.GET("/health").WithHeader("Origin", "https://trusted.example.com").Expect().Status(http.StatusOK).Raw()
+	got := resp.Header.Get("Access-Control-Allow-Origin")
+	if got != "https://trusted.example.com" {
+		t.Errorf("expected Access-Control-Allow-Origin: https://trusted.example.com, got %q", got)
+	}
+
+	// Unlisted origin must not receive the header.
+	resp2 := e.GET("/health").WithHeader("Origin", "https://evil.com").Expect().Status(http.StatusOK).Raw()
+	if resp2.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin for unlisted origin, got %q",
+			resp2.Header.Get("Access-Control-Allow-Origin"))
+	}
 }
 
 func TestAdminCreateRecordInvalidValue(t *testing.T) {

--- a/config.cfg
+++ b/config.cfg
@@ -9,7 +9,7 @@ protocol = "both"
 domain = "auth.example.org"
 # zone name server
 nsname = "auth.example.org"
-# admin email address, where @ is substituted with .
+# admin email address, where @ is substituted with .
 nsadmin = "admin.example.org"
 # predefined records served in addition to the TXT
 records = [
@@ -46,17 +46,19 @@ acme_cache_dir = "api-certs"
 # optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
 notification_email = ""
 # CORS AllowOrigins, wildcards can be used
-corsorigins = [
-    "*"
-]
+# WARNING: empty list denies all cross-origin requests (secure default)
+# Set explicitly for browser-based clients, e.g.: corsorigins = ["https://admin.example.com"]
+corsorigins = []
 # use HTTP header to get the client ip
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+# max registrations per minute per source IP (0 = unlimited)
+register_ratelimit = 10
 
-# To enable the admin API, add an [api.admin] section with a secret token:
-# [api.admin]
-# token = "your-secret-admin-token-here"
+# Admin API — leave token empty to disable admin endpoints or remove the section from your config
+#[api.admin]
+#token = ""
 
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"

--- a/db.go
+++ b/db.go
@@ -200,11 +200,22 @@ func (d *acmedb) handleDBUpgradeTo2() error {
 
 // Create two rows for subdomain to the txt table
 func (d *acmedb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
-	var err error
-	instr := fmt.Sprintf("INSERT INTO txt (Subdomain, LastUpdate) values('%s', 0)", subdomain)
-	_, _ = tx.Exec(instr)
-	_, _ = tx.Exec(instr)
-	return err
+	stmt := "INSERT INTO txt (Subdomain, LastUpdate) values($1, 0)"
+	if Config.Database.Engine == "sqlite3" {
+		stmt = getSQLiteStmt(stmt)
+	}
+	ps, err := tx.Prepare(stmt)
+	if err != nil {
+		return err
+	}
+	defer closeStatement(ps)
+	if _, err := ps.Exec(subdomain); err != nil {
+		return err
+	}
+	if _, err := ps.Exec(subdomain); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
@@ -222,7 +233,7 @@ func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
 	}()
 	a := newACMETxt()
 	a.AllowFrom = afrom.ValidEntries()
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(a.Password), 10)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(a.Password), 12)
 	regSQL := `
     INSERT INTO records(
         Username,
@@ -460,10 +471,14 @@ func (d *acmedb) Close() {
 }
 
 func (d *acmedb) GetBackend() *sql.DB {
+	d.Lock()
+	defer d.Unlock()
 	return d.DB
 }
 
 func (d *acmedb) SetBackend(backend *sql.DB) {
+	d.Lock()
+	defer d.Unlock()
 	d.DB = backend
 }
 

--- a/main.go
+++ b/main.go
@@ -115,19 +115,24 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsServers []*DNSServer)
 	legolog.Logger = logger
 
 	api := httprouter.New()
-	c := cors.New(cors.Options{
-		AllowedOrigins:     config.API.CorsOrigins,
-		AllowedMethods:     []string{"GET", "POST", "PUT", "DELETE"},
-		AllowedHeaders:     []string{"Authorization", "Content-Type", "X-Api-User", "X-Api-Key"},
-		OptionsPassthrough: false,
-		Debug:              config.General.Debug,
-	})
+	corsOpts := buildCORSOptions(
+		config.API.CorsOrigins,
+		[]string{"GET", "POST", "PUT", "DELETE"},
+		[]string{"Authorization", "Content-Type", "X-Api-User", "X-Api-Key"},
+	)
+	corsOpts.OptionsPassthrough = false
+	corsOpts.Debug = config.General.Debug
+	c := cors.New(corsOpts)
 	if config.General.Debug {
 		// Logwriter for saner log output
 		c.Log = stdlog.New(logWriter, "", 0)
 	}
+	var registerLimiter *rateLimiter
+	if config.API.RegisterRateLimit > 0 {
+		registerLimiter = newRateLimiter(config.API.RegisterRateLimit)
+	}
 	if !config.API.DisableRegistration {
-		api.POST("/register", webRegisterPost)
+		api.POST("/register", rateLimitMiddleware(registerLimiter, webRegisterPost))
 	}
 	api.POST("/update", Auth(webUpdatePost))
 	api.GET("/health", healthCheck)

--- a/types.go
+++ b/types.go
@@ -52,6 +52,7 @@ type httpapi struct {
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+	RegisterRateLimit   int    `toml:"register_ratelimit"`
 	Admin               adminconfig
 }
 

--- a/util.go
+++ b/util.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"os"
 	"regexp"
@@ -14,7 +14,8 @@ import (
 )
 
 func jsonError(message string) []byte {
-	return []byte(fmt.Sprintf("{\"error\": \"%s\"}", message))
+	b, _ := json.Marshal(map[string]string{"error": message})
+	return b
 }
 
 func fileIsAccessible(fName string) bool {

--- a/util_test.go
+++ b/util_test.go
@@ -148,6 +148,23 @@ func TestPrepareConfig(t *testing.T) {
 	}
 }
 
+func TestJsonErrorWithSpecialChars(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"simple error", `{"error":"simple error"}`},
+		{`error with "quotes"`, `{"error":"error with \"quotes\""}`},
+		{"error with\nnewline", `{"error":"error with\nnewline"}`},
+	}
+	for _, tc := range cases {
+		got := string(jsonError(tc.input))
+		if got != tc.expected {
+			t.Errorf("jsonError(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
 func cleanupTmpFile(tmpFile string) {
 	if err := os.Remove(tmpFile); err != nil {
 		panic("Could not remove temporary file")


### PR DESCRIPTION
## Summary

- Raised bcrypt cost factor from 10 to 12
- Fixed `jsonError` to use `json.Marshal` (prevents unescaped special characters in error responses)
- Fixed SQL injection pattern in `NewTXTValuesInTransaction` (parameterized query + prepared statement)
- Fixed goroutine leak in rate limiter: replaced `time.Tick` with `time.NewTicker` + `stop()` method
- Hardened CORS default: `corsorigins` now defaults to `[]` (deny all cross-origin) instead of `["*"]`; extracted `buildCORSOptions` and added unit tests
- Added per-IP rate limiting on `/register` via `register_ratelimit` config option (default 10/min), documented in the README's Register endpoint and Configuration sections
- Added a High Availability Deployment section to the README (Prerequisites, DB/instance config, DNS load balancing, HTTP load balancing with Nginx and Apache2 examples, health checks, failure modes, upgrade procedure, security notes)

## Test Plan

- [x] `go test -race ./...` passes
- [x] `go build ./...` builds cleanly
- [x] `POST /register` from same IP beyond limit returns 429
- [x] Different IPs are rate-limited independently
- [x] `corsorigins = []` blocks cross-origin requests by default