### PR TITLE
fix: Correct MX value docs and validate admin record names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,16 @@
     - Store custom DNS records in a database (A, AAAA, NS, TXT, CNAME, MX, SOA, SRV, PTR)
     - Comprehensive DNS record validation (type, value, TTL)
   - Changed
-    - DNS server now serves both challenge records and managed records from database
+    - DNS server now serves both challenge records and managed records from the database
     - FQDN normalization on ingress for consistency
     - Added database index for efficient record lookups
     - Raised bcrypt cost factor from 10 to 12
     - `jsonError` now uses `json.Marshal` to safely encode error messages
+    - Corrected README documentation for the MX record `value` format (requires a preference before the exchange hostname, e.g. `0 mail.example.com.`) and added test coverage for MX record creation and serving
   - Security
     - Fixed SQL injection pattern in `NewTXTValuesInTransaction` (defense-in-depth, input was already sanitized)
     - Added per-IP rate limiting on `/register` endpoint (`register_ratelimit` config option)
+    - Added validation for the admin record `name` field to reject whitespace/control characters before it is spliced into RR strings for DNS responses (defense-in-depth)
 - v0.21.6:
   - Changed
     - Update base image to golang:1.26-alpine3.23

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Create a new DNS record.
 - `value`: Record value (required)
   - A: IPv4 address
   - AAAA: IPv6 address
-  - NS, CNAME, PTR, MX: Hostname
+  - NS, CNAME, PTR: Hostname
+  - MX: `<preference> <exchange hostname>`, e.g. `0 mail.example.com.`
   - TXT: Text string (automatically quoted if not already)
   - SRV: Service record format
 - `ttl`: Time-to-live in seconds (optional, defaults to 300)
@@ -377,7 +378,7 @@ protocol = "both"
 domain = "auth.example.org"
 # zone name server
 nsname = "auth.example.org"
-# admin email address, where @ is substituted with .
+# admin email address, where @ is substituted with .
 nsadmin = "admin.example.org"
 # predefined records served in addition to the TXT
 records = [

--- a/api.go
+++ b/api.go
@@ -213,7 +213,7 @@ func adminCreateRecord(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 		_, _ = w.Write(jsonError("malformed_json_payload"))
 		return
 	}
-	if req.Name == "" {
+	if !validRecordName(req.Name) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write(jsonError("invalid_name"))
@@ -277,7 +277,7 @@ func adminUpdateRecord(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		_, _ = w.Write(jsonError("malformed_json_payload"))
 		return
 	}
-	if req.Name == "" {
+	if !validRecordName(req.Name) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write(jsonError("invalid_name"))

--- a/api_test.go
+++ b/api_test.go
@@ -495,6 +495,17 @@ func TestAdminCreateRecord(t *testing.T) {
 		JSON().Object().ContainsKey("id")
 }
 
+func TestAdminCreateRecordInvalidName(t *testing.T) {
+	_, e := setupAdminRouter(t, "test-token")
+
+	body := map[string]interface{}{"name": "foo bar\n.example.com", "type": "A", "value": "1.2.3.4", "ttl": 300}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(body).
+		Expect().
+		Status(http.StatusBadRequest)
+}
+
 func TestAdminCreateRecordInvalidType(t *testing.T) {
 	_, e := setupAdminRouter(t, "test-token")
 
@@ -594,6 +605,13 @@ func TestAdminUpdateRecord(t *testing.T) {
 		WithHeader("Authorization", "Bearer test-token").
 		WithJSON(invalidTypeBody).
 		Expect().Status(http.StatusBadRequest)
+
+	// Invalid-name case: should return 400
+	invalidNameBody := map[string]interface{}{"name": "foo bar\n.example.com", "type": "A", "value": "5.6.7.8", "ttl": 60}
+	e.PUT("/admin/records/"+id).
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(invalidNameBody).
+		Expect().Status(http.StatusBadRequest)
 }
 
 func TestAdminWrongToken(t *testing.T) {
@@ -677,6 +695,21 @@ func TestAdminCreateRecordInvalidValue(t *testing.T) {
 		WithHeader("Authorization", "Bearer test-token").
 		WithJSON(payload).
 		Expect().Status(http.StatusBadRequest)
+}
+
+func TestAdminCreateMXRecord(t *testing.T) {
+	// MX values must carry a preference before the exchange hostname, e.g. "0 mail.example.com."
+	_, e := setupAdminRouter(t, "test-token")
+	payload := map[string]interface{}{
+		"name":  "mx.example.com",
+		"type":  "MX",
+		"value": "0 mail.example.com.",
+		"ttl":   300,
+	}
+	e.POST("/admin/records").
+		WithHeader("Authorization", "Bearer test-token").
+		WithJSON(payload).
+		Expect().Status(http.StatusCreated).JSON().Object().ContainsKey("id")
 }
 
 func TestAdminCreateRecordInvalidMXValue(t *testing.T) {

--- a/dns_test.go
+++ b/dns_test.go
@@ -326,6 +326,36 @@ func TestAnswerManagedNODATA(t *testing.T) {
 	}
 }
 
+func TestAnswerManagedMXRecord(t *testing.T) {
+	// MX value must be "<preference> <exchange>", e.g. "0 mail.example.com."
+	rec := DNSRecord{
+		ID: "mx-test-1", Name: "mx.auth.example.org.", Type: "MX", Value: "10 mail.example.org.", TTL: 300, Created: 0,
+	}
+	if err := DB.CreateRecord(rec); err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.DeleteRecord("mx-test-1") })
+
+	q := dns.Question{Name: "mx.auth.example.org.", Qtype: dns.TypeMX, Qclass: dns.ClassINET}
+	rrs, rcode, _, err := dnsserver.answer(q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Fatalf("expected NOERROR for MX query, got %s", dns.RcodeToString[rcode])
+	}
+	if len(rrs) != 1 {
+		t.Fatalf("expected exactly one RR in answer, got %d", len(rrs))
+	}
+	mx, ok := rrs[0].(*dns.MX)
+	if !ok {
+		t.Fatalf("expected *dns.MX, got %T", rrs[0])
+	}
+	if mx.Preference != 10 || mx.Mx != "mail.example.org." {
+		t.Fatalf("expected preference 10 and mx mail.example.org., got preference %d and mx %s", mx.Preference, mx.Mx)
+	}
+}
+
 func TestAnswerManagedCAARecord(t *testing.T) {
 	// CAA value must not be quote-wrapped — it has its own tag-value structure.
 	rec := DNSRecord{

--- a/validation.go
+++ b/validation.go
@@ -49,6 +49,26 @@ func correctPassword(pw string, hash string) bool {
 	return false
 }
 
+// hostnameLabelRegExp matches a single DNS label: alphanumerics and underscores,
+// with hyphens allowed only in the interior (not leading/trailing).
+var hostnameLabelRegExp = regexp.MustCompile(`^[A-Za-z0-9_]([A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?$`)
+
+func validRecordName(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	labels := strings.Split(strings.TrimSuffix(s, "."), ".")
+	for _, label := range labels {
+		if label == "*" {
+			continue
+		}
+		if !hostnameLabelRegExp.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
+
 func validRecordType(typ string) bool {
 	switch typ {
 	case "A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA", "PTR":

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -171,6 +172,36 @@ func TestValidRecordValue(t *testing.T) {
 		got := validRecordValue(tc.rtype, tc.value)
 		if got != tc.valid {
 			t.Errorf("validRecordValue(%q, %q) = %v, want %v", tc.rtype, tc.value, got, tc.valid)
+		}
+	}
+}
+
+func TestValidRecordName(t *testing.T) {
+	cases := []struct {
+		name  string
+		valid bool
+	}{
+		{"example.com", true},
+		{"sub.example.com", true},
+		{"_dmarc.example.com", true},
+		{"_sip._tcp.example.com", true},
+		{"*.example.com", true},
+		{"example.com.", true},
+		{"localhost", true},
+		{"", false},
+		{"foo bar.example.com", false},
+		{"foo\nexample.com", false},
+		{"foo\texample.com", false},
+		{"-foo.example.com", false},
+		{"foo-.example.com", false},
+		{"foo..example.com", false},
+		{strings.Repeat("a", 64) + ".example.com", false},
+		{strings.Repeat("a.", 127) + "com", false},
+	}
+	for _, tc := range cases {
+		got := validRecordName(tc.name)
+		if got != tc.valid {
+			t.Errorf("validRecordName(%q) = %v, want %v", tc.name, got, tc.valid)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- README documented MX record values as a bare hostname, but the DNS spec (and this codebase's own `probeRR` validation via `dns.NewRR`) requires a preference before the exchange host, e.g. `10 mail.example.com.`. Following the old docs made every MX creation fail with `invalid_record_value`. Docs are now corrected, and the previously untested MX create → serve path has test coverage (`TestAdminCreateMXRecord`, `TestAnswerManagedMXRecord`) proving the existing validation/serving logic was already correct.
- Hardened admin record name validation: `adminCreateRecord`/`adminUpdateRecord` previously only rejected an empty `name`, so a name containing whitespace or control characters (e.g. a newline) would be stored and later spliced unescaped into the RR string built for DNS responses. Added `validRecordName` (label length/charset checks, blocks whitespace/newlines, allows `_`-prefixed labels and wildcard `*`) and wired it into both handlers.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
